### PR TITLE
Unique rule names for multiple CloudWatch expressions

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2058,15 +2058,29 @@ USE_TZ = True
         )
         self.assertTrue(len(truncated) == 64)
 
-        rule_name = zappa.get_hashed_rule_name(
+        rule_name_index0 = zappa.get_hashed_rule_name(
             event=dict(name="some-event-name"),
             function="this.is.my.dang.function.wassup.yeah.its.long",
             lambda_name="basldfkjalsdkfjalsdkfjaslkdfjalsdkfjadlsfkjasdlfkjasdlfkjasdflkjasdf-asdfasdfasdfasdfasdf",
+            index=0,
         )
-        self.assertTrue(len(rule_name) <= 64)
+        self.assertTrue(len(rule_name_index0) <= 64)
         self.assertTrue(
-            rule_name.endswith("-this.is.my.dang.function.wassup.yeah.its.long")
+            rule_name_index0.endswith("-this.is.my.dang.function.wassup.yeah.its.long")
         )
+
+        rule_name_index1 = zappa.get_hashed_rule_name(
+            event=dict(name="some-event-name"),
+            function="this.is.my.dang.function.wassup.yeah.its.long",
+            lambda_name="basldfkjalsdkfjalsdkfjaslkdfjalsdkfjadlsfkjasdlfkjasdlfkjasdflkjasdf-asdfasdfasdfasdfasdf",
+            index=1,
+        )
+        self.assertTrue(len(rule_name_index1) <= 64)
+        self.assertTrue(
+            rule_name_index1.endswith("-this.is.my.dang.function.wassup.yeah.its.long")
+        )
+
+        self.assertNotEqual(rule_name_index0, rule_name_index1)
 
     def test_detect_dj(self):
         # Sanity


### PR DESCRIPTION
## Description

A mixture of two cases that were handled individually uncovers an incorrect behavior: when a function has multiple event expressions AND the resulting rule name would be >= 64 characters long, all expressions get the same hash, so only the last expression is scheduled.

In my fix, the index of the expression is used to build the hash, but only if the index is not zero. My rationale for this was preserving hashes for current rules. This seems unneeded (it doesn't seem like it would break anything without caring about this) but may prevent surprises. I'd like some feedback on whether this is an appropriate choice.

## GitHub Issues

https://github.com/Miserlou/Zappa/issues/1727

## Original PR

https://github.com/Miserlou/Zappa/pull/2102