### PR TITLE
Fix two errors on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,13 @@ from setuptools import setup
 from io import open
 from zappa import __version__
 
-with open('README.md') as readme_file:
+with open('README.md', encoding='utf-8') as readme_file:
     long_description = readme_file.read()
 
-with open(os.path.join(os.path.dirname(__file__), 'requirements.in')) as f:
+with open(os.path.join(os.path.dirname(__file__), 'requirements.in'), encoding='utf-8') as f:
     required = f.read().splitlines()
 
-with open(os.path.join(os.path.dirname(__file__), 'test_requirements.in')) as f:
+with open(os.path.join(os.path.dirname(__file__), 'test_requirements.in'), encoding='utf-8') as f:
     test_required = f.read().splitlines()
 
 setup(

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -754,11 +754,11 @@ class Zappa:
         archivef.close()
 
         # Trash the temp directory
-        shutil.rmtree(temp_project_path)
-        shutil.rmtree(temp_package_path)
+        shutil.rmtree(temp_project_path, ignore_errors=True)
+        shutil.rmtree(temp_package_path, ignore_errors=True)
         if os.path.isdir(venv) and slim_handler:
             # Remove the temporary handler venv folder
-            shutil.rmtree(venv)
+            shutil.rmtree(venv, ignore_errors=True)
 
         return archive_fname
 


### PR DESCRIPTION
This PR fixes two small errors on windows
First one is that only empty directory's can be deleted and second one is the encoding of readme when installing from master via pip