### PR TITLE
Add try/except to avoid error on deleting unretained version with alias

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1161,7 +1161,12 @@ class Zappa:
             versions_in_lambda.remove('$LATEST')
             # Delete older revisions if their number exceeds the specified limit
             for version in versions_in_lambda[::-1][num_revisions:]:
-                self.lambda_client.delete_function(FunctionName=function_name,Qualifier=version)
+                try:
+                    self.lambda_client.delete_function(FunctionName=function_name,Qualifier=version)
+                except botocore.exceptions.ClientError as e:
+                    if e.response['Error']['Code'] == 'ResourceConflictException':
+                        continue
+                    raise
 
         return resource_arn
 


### PR DESCRIPTION
## Description
If the `num_retained_version` is set in the `zappa_settings.py` and an alias has been created manually from the AWS Console, the zappa update fails if the version the alias is on is an unretained version.

## GitHub Issues
Problem describe in the following issue : #960.

