### PR TITLE
Allow `run(func, args, kwargs)` function to works in local

### DIFF
--- a/zappa/asynchronous.py
+++ b/zappa/asynchronous.py
@@ -351,10 +351,16 @@ def run(func, args=[], kwargs={}, service='lambda', capture_response=False,
     aws_region = remote_aws_region or os.environ.get('AWS_REGION')
 
     task_path = get_func_task_path(func)
-    return ASYNC_CLASSES[service](lambda_function_name=lambda_function_name,
-                                  aws_region=aws_region,
-                                  capture_response=capture_response,
-                                  **task_kwargs).send(task_path, args, kwargs)
+    # This conditional is used to allow function execution in local
+    # Related: https://github.com/Miserlou/Zappa/issues/1774
+    if (service in ASYNC_CLASSES) and (lambda_function_name):
+        return ASYNC_CLASSES[service](lambda_function_name=lambda_function_name,
+                                      aws_region=aws_region,
+                                      capture_response=capture_response,
+                                      **task_kwargs).send(task_path, args, kwargs)
+    else:
+        return func(*args, **kwargs)
+
 
 
 # Handy:


### PR DESCRIPTION
Really bad move from me... I think I deleted the wrong fork few days ago.
Just recreating this PR from this one : https://github.com/Miserlou/Zappa/pull/2129

Link to this issue : #875 
It even seems it's a duplicated issue : #694