### PR TITLE
Download wheels using compressed platform tags

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -281,7 +281,7 @@ class Zappa:
 
         # AWS Lambda supports manylinux1/2010 and manylinux2014
         manylinux_suffixes = ("2014", "2010", "1")
-        self.manylinux_wheel_file_match = re.compile(f'^.*{self.manylinux_suffix_start}-manylinux({"|".join(manylinux_suffixes)})_x86_64.whl$')
+        self.manylinux_wheel_file_match = re.compile(f'^.*{self.manylinux_suffix_start}-.*manylinux({"|".join(manylinux_suffixes)})_x86_64.*.whl$')
         self.manylinux_wheel_abi3_file_match = re.compile(f'^.*cp3.-abi3-manylinux({"|".join(manylinux_suffixes)})_x86_64.whl$')
 
         self.endpoint_urls = endpoint_urls
@@ -650,6 +650,7 @@ class Zappa:
                 for installed_package_name, installed_package_version in installed_packages.items():
                     cached_wheel_path = self.get_cached_manylinux_wheel(installed_package_name, installed_package_version, disable_progress)
                     if cached_wheel_path:
+                        logger.info("Using precompiled package '%s'" % cached_wheel_path)
                         # Otherwise try to use manylinux packages from PyPi..
                         # Related: https://github.com/Miserlou/Zappa/issues/398
                         shutil.rmtree(os.path.join(temp_project_path, installed_package_name), ignore_errors=True)

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2134,7 +2134,7 @@ class Zappa:
 
         # build a fresh template
         self.cf_template = troposphere.Template()
-        self.cf_template.add_description('Automatically generated with Zappa')
+        self.cf_template.set_description('Automatically generated with Zappa')
         self.cf_api_resources = []
         self.cf_parameters = {}
 


### PR DESCRIPTION
More than one tag can be included in a wheel file as specified in PEP
425 (https://www.python.org/dev/peps/pep-0425/#compressed-tag-sets).

This is a quick fix to allow download wheels with multiple platform
tags (i.e. numpy).

<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/zappa/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.6**, **Python 3.7** and **Python 3.8** ? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

