### PR TITLE
ACME V1 Was Deprecated, Use V2

### DIFF
--- a/zappa/letsencrypt.py
+++ b/zappa/letsencrypt.py
@@ -34,7 +34,7 @@ import requests
 # DEFAULT_CA = "https://acme-staging.api.letsencrypt.org"
 
 # Production
-DEFAULT_CA = "https://acme-v01.api.letsencrypt.org"
+DEFAULT_CA = "https://acme-v02.api.letsencrypt.org"
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.StreamHandler())


### PR DESCRIPTION
We're using acme v1 which got EOLed. 

https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430

This is causing our unit tests to fail and who knows what else down stream. 