### PR TITLE
wait for lambda to become active during deploy/update

### DIFF
--- a/tests/placebo/TestZappa.test_cli_aws/lambda.GetFunctionConfiguration_1.json
+++ b/tests/placebo/TestZappa.test_cli_aws/lambda.GetFunctionConfiguration_1.json
@@ -1,33 +1,7 @@
 {
     "status_code": 200,
     "data": {
-        "ResponseMetadata": {
-            "RequestId": "8cd3e440-6d74-11e7-9ebd-693a5cc9b121",
-            "HTTPStatusCode": 200,
-            "HTTPHeaders": {
-                "content-type": "application/json",
-                "date": "Thu, 20 Jul 2017 17:54:59 GMT",
-                "x-amzn-requestid": "8cd3e440-6d74-11e7-9ebd-693a5cc9b121",
-                "content-length": "609",
-                "connection": "keep-alive"
-            },
-            "RetryAttempts": 0
-        },
-        "FunctionName": "zappa-ttt888",
-        "FunctionArn": "arn:aws:lambda:us-east-1:004396165043:function:zappa-ttt888",
-        "Runtime": "python3.6",
-        "Role": "arn:aws:iam::004396165043:role/zappa-ttt888-ZappaLambdaExecutionRole",
-        "Handler": "handler.lambda_handler",
-        "CodeSize": 16975308,
-        "Description": "Zappa Deployment",
-        "Timeout": 30,
-        "MemorySize": 512,
-        "LastModified": "2017-07-20T17:54:59.235+0000",
-        "CodeSha256": "0pOcmP7sDoO6mLbZKmtH5z0XyjT8wuu/1VenHLgu/MU=",
-        "Version": "$LATEST",
-        "Environment": {
-            "Variables": {}
-        },
-        "PackageType": "Zip"
+        "State": "Active",
+        "LastUpdateStatus": "Successful"
     }
 }

--- a/tests/placebo/TestZappa.test_cli_aws/lambda.GetFunctionConfiguration_2.json
+++ b/tests/placebo/TestZappa.test_cli_aws/lambda.GetFunctionConfiguration_2.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "8cd3e440-6d74-11e7-9ebd-693a5cc9b121",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "date": "Thu, 20 Jul 2017 17:54:59 GMT",
+                "x-amzn-requestid": "8cd3e440-6d74-11e7-9ebd-693a5cc9b121",
+                "content-length": "609",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        },
+        "FunctionName": "zappa-ttt888",
+        "FunctionArn": "arn:aws:lambda:us-east-1:004396165043:function:zappa-ttt888",
+        "Runtime": "python3.6",
+        "Role": "arn:aws:iam::004396165043:role/zappa-ttt888-ZappaLambdaExecutionRole",
+        "Handler": "handler.lambda_handler",
+        "CodeSize": 16975308,
+        "Description": "Zappa Deployment",
+        "Timeout": 30,
+        "MemorySize": 512,
+        "LastModified": "2017-07-20T17:54:59.235+0000",
+        "CodeSha256": "0pOcmP7sDoO6mLbZKmtH5z0XyjT8wuu/1VenHLgu/MU=",
+        "Version": "$LATEST",
+        "Environment": {
+            "Variables": {}
+        },
+        "PackageType": "Zip"
+    }
+}

--- a/tests/placebo/TestZappa.test_create_lambda_function_docker/lambda.GetFunctionConfiguration_1.json
+++ b/tests/placebo/TestZappa.test_create_lambda_function_docker/lambda.GetFunctionConfiguration_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "State": "Active",
+        "LastUpdateStatus": "Successful"
+    }
+}

--- a/tests/placebo/TestZappa.test_create_lambda_function_local/lambda.GetFunctionConfiguration_1.json
+++ b/tests/placebo/TestZappa.test_create_lambda_function_local/lambda.GetFunctionConfiguration_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "State": "Active",
+        "LastUpdateStatus": "Successful"
+    }
+}

--- a/tests/placebo/TestZappa.test_create_lambda_function_s3/lambda.GetFunctionConfiguration_1.json
+++ b/tests/placebo/TestZappa.test_create_lambda_function_s3/lambda.GetFunctionConfiguration_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "State": "Active",
+        "LastUpdateStatus": "Successful"
+    }
+}

--- a/tests/tests_placebo.py
+++ b/tests/tests_placebo.py
@@ -176,13 +176,6 @@ class TestZappa(unittest.TestCase):
             z.rollback_lambda_function_version(function_name)
 
     @placebo_session
-    def test_is_lambda_function_ready(self, session):
-        z = Zappa(session)
-        z.credentials_arn = "arn:aws:iam::724336686645:role/ZappaLambdaExecution"
-        function_name = "django-helloworld-unicode"
-        z.is_lambda_function_ready(function_name)
-
-    @placebo_session
     def test_invoke_lambda_function(self, session):
         z = Zappa(session)
         z.credentials_arn = "arn:aws:iam::724336686645:role/ZappaLambdaExecution"

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -996,7 +996,7 @@ class ZappaCLI:
                     )
 
             if self.stage_config.get("touch", True):
-                self.zappa.wait_until_lambda_function_is_ready(
+                self.zappa.wait_until_lambda_function_is_updated(
                     function_name=self.lambda_name
                 )
                 self.touch_endpoint(endpoint_url)
@@ -1260,7 +1260,7 @@ class ZappaCLI:
                     deployed_string = deployed_string + " (" + api_url + ")"
 
             if self.stage_config.get("touch", True):
-                self.zappa.wait_until_lambda_function_is_ready(
+                self.zappa.wait_until_lambda_function_is_updated(
                     function_name=self.lambda_name
                 )
                 if api_url:

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1140,9 +1140,6 @@ class ZappaCLI:
         if docker_image_uri:
             kwargs["docker_image_uri"] = docker_image_uri
             self.lambda_arn = self.zappa.update_lambda_function(**kwargs)
-            self.zappa.wait_until_lambda_function_is_ready(
-                function_name=self.lambda_name
-            )
         elif source_zip and source_zip.startswith("s3://"):
             bucket, key_name = parse_s3_url(source_zip)
             kwargs.update(dict(bucket=bucket, s3_key=key_name))

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1171,6 +1171,7 @@ class ZappaCLI:
             aws_environment_variables=self.aws_environment_variables,
             aws_kms_key_arn=self.aws_kms_key_arn,
             layers=self.layers,
+            wait=False,
         )
 
         # Finally, delete the local copy our zip package

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1248,7 +1248,7 @@ class Zappa:
             )
 
         # Wait for lambda to become active, otherwise many operations will fail
-        self.wait_until_lambda_function_is_ready(function_name)
+        self.wait_until_lambda_function_is_active(function_name)
 
         return resource_arn
 
@@ -1370,7 +1370,7 @@ class Zappa:
             layers = []
 
         # Wait until function is ready, otherwise expected keys will be missing from 'lambda_aws_config'.
-        self.wait_until_lambda_function_is_ready(function_name)
+        self.wait_until_lambda_function_is_updated(function_name)
 
         # Check if there are any remote aws lambda env vars so they don't get trashed.
         # https://github.com/Miserlou/Zappa/issues/987,  Related: https://github.com/Miserlou/Zappa/issues/765
@@ -1489,18 +1489,23 @@ class Zappa:
 
         return response["FunctionArn"]
 
-    def wait_until_lambda_function_is_ready(self, function_name):
+    def wait_until_lambda_function_is_active(self, function_name):
         """
-        Wait until lambda State=Active and LastUpdateStatus=Successful
+        Wait until lambda State=Active
         """
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html#waiters
-        kwargs = {"FunctionName": function_name}
         waiter = self.lambda_client.get_waiter("function_active")
         print(f"Waiting for lambda function [{function_name}] to become active...")
-        waiter.wait(**kwargs)
+        waiter.wait(FunctionName=function_name)
+
+    def wait_until_lambda_function_is_updated(self, function_name):
+        """
+        Wait until lambda LastUpdateStatus=Successful
+        """
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html#waiters
         waiter = self.lambda_client.get_waiter("function_updated")
         print(f"Waiting for lambda function [{function_name}] to be updated...")
-        waiter.wait(**kwargs)
+        waiter.wait(FunctionName=function_name)
 
     def get_lambda_function(self, function_name):
         """

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1369,6 +1369,9 @@ class Zappa:
         if not layers:
             layers = []
 
+        # Wait until function is ready, otherwise expected keys will be missing from 'lambda_aws_config'.
+        self.wait_until_lambda_function_is_ready(function_name)
+
         # Check if there are any remote aws lambda env vars so they don't get trashed.
         # https://github.com/Miserlou/Zappa/issues/987,  Related: https://github.com/Miserlou/Zappa/issues/765
         lambda_aws_config = self.lambda_client.get_function_configuration(

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1336,6 +1336,8 @@ class Zappa:
                     FunctionName=function_name, Qualifier=version
                 )
 
+        self.wait_until_lambda_function_is_updated(function_name)
+
         return resource_arn
 
     def update_lambda_configuration(
@@ -1352,6 +1354,7 @@ class Zappa:
         aws_environment_variables=None,
         aws_kms_key_arn=None,
         layers=None,
+        wait=True,
     ):
         """
         Given an existing function ARN, update the configuration variables.
@@ -1369,8 +1372,9 @@ class Zappa:
         if not layers:
             layers = []
 
-        # Wait until function is ready, otherwise expected keys will be missing from 'lambda_aws_config'.
-        self.wait_until_lambda_function_is_updated(function_name)
+        if wait:
+            # Wait until function is ready, otherwise expected keys will be missing from 'lambda_aws_config'.
+            self.wait_until_lambda_function_is_updated(function_name)
 
         # Check if there are any remote aws lambda env vars so they don't get trashed.
         # https://github.com/Miserlou/Zappa/issues/987,  Related: https://github.com/Miserlou/Zappa/issues/765


### PR DESCRIPTION
Many parts of the deployment process (e.g., scheduling certain events, setting up alb target groups) will fail if the lambda function is not in a ready state, this pr attempts to alleviate that by using a boto waiter during the lambda creation function.