### PR TITLE
relax stage name restrictions when not using apigateway

### DIFF
--- a/tests/test_bad_stage_name_settings.json
+++ b/tests/test_bad_stage_name_settings.json
@@ -1,5 +1,6 @@
 {
     "ttt-888": {
+       "apigateway_enabled": true,
        "touch": false,
        "s3_bucket": "lmbda",
        "app_function": "tests.test_app.hello_world",
@@ -29,6 +30,7 @@
        ]
     },
     "devor": {
+       "apigateway_enabled": true,
        "s3_bucket": "lmbda",
        "app_function": "tests.test_app.hello_world",
        "callbacks": {

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1424,11 +1424,9 @@ class TestZappa(unittest.TestCase):
 
     def test_bad_stage_name_catch(self):
         zappa_cli = ZappaCLI()
-        self.assertRaises(
-            ValueError,
-            zappa_cli.load_settings,
-            "tests/test_bad_stage_name_settings.json",
-        )
+        zappa_cli.api_stage = "ttt-888"
+        zappa_cli.load_settings("tests/test_bad_stage_name_settings.json")
+        self.assertRaises(ValueError, zappa_cli.dispatch_command, "deploy", "ttt-888")
 
     def test_bad_environment_vars_catch(self):
         zappa_cli = ZappaCLI()

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -596,7 +596,7 @@ class ZappaCLI:
         Given a command to execute and stage,
         execute that command.
         """
-
+        self.check_stage_name(stage)
         self.api_stage = stage
 
         if command not in ["status", "manage"]:
@@ -1789,9 +1789,15 @@ class ZappaCLI:
         calling the CreateDeployment operation: Stage name only allows
         a-zA-Z0-9_" if the pattern does not match)
         """
+        if not self.use_apigateway:
+            return True
         if self.stage_name_env_pattern.match(stage_name):
             return True
-        raise ValueError("AWS requires stage name to match a-zA-Z0-9_")
+        raise ValueError(
+            "API stage names must match a-zA-Z0-9_ ; '{0!s}' does not.".format(
+                stage_name
+            )
+        )
 
     def check_environment(self, environment):
         """
@@ -2482,17 +2488,6 @@ class ZappaCLI:
 
         # Load up file
         self.load_settings_file(settings_file)
-
-        # Make sure that the stages are valid names:
-        for stage_name in self.zappa_settings.keys():
-            try:
-                self.check_stage_name(stage_name)
-            except ValueError:
-                raise ValueError(
-                    "API stage names must match a-zA-Z0-9_ ; '{0!s}' does not.".format(
-                        stage_name
-                    )
-                )
 
         # Make sure that this stage is our settings
         if self.api_stage not in self.zappa_settings.keys():


### PR DESCRIPTION
Stage name restrictions are in place due to limitations on the naming of CloudFormation stacks which is not a concern when API Gateway is not in use.