### PR TITLE
Template: add_description -> set_description (stratosphere 3.x).

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2414,7 +2414,7 @@ class Zappa:
 
         # build a fresh template
         self.cf_template = troposphere.Template()
-        self.cf_template.add_description("Automatically generated with Zappa")
+        self.cf_template.set_description("Automatically generated with Zappa")
         self.cf_api_resources = []
         self.cf_parameters = {}
 


### PR DESCRIPTION
## Description
As `stratosphere` has been upgraded to `3.0.1` , `add_description` is deprecated and removed. `set_description` should be used instead.

## GitHub Issues

https://github.com/zappa/Zappa/issues/998
