### PR TITLE
Template.add_desciption() no longer supported in Troposhere

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2414,7 +2414,7 @@ class Zappa:
 
         # build a fresh template
         self.cf_template = troposphere.Template()
-        self.cf_template.add_description("Automatically generated with Zappa")
+        self.cf_template.set_description("Automatically generated with Zappa")
         self.cf_api_resources = []
         self.cf_parameters = {}
 


### PR DESCRIPTION
Template.add_desciption() no longer supported in Troposhere

This breaks zappa deploy and update.  Problem mentioned in this ticket:
https://github.com/Miserlou/Zappa/issues/2223

Template.add_description() changed to Template.set_description() in Troposphere 3.0.0:
https://github.com/cloudtools/troposphere/blob/main/CHANGELOG.rst#:~:text=add_description()%20%3D%3E%20set_description()%20add_metadata()%20%3D%3E%20set_metadata()%20add_transform()%20%3D%3E%20set_transform()%20add_version()%20%3D%3E%20set_version()


