### PR TITLE
add_description() not exist on Template

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2413,8 +2413,8 @@ class Zappa:
             auth_type = authorizer.get("type", "CUSTOM")
 
         # build a fresh template
-        self.cf_template = troposphere.Template()
-        self.cf_template.add_description("Automatically generated with Zappa")
+        self.cf_template = troposphere.Template(Description="Automatically generated with Zappa")
+        # self.cf_template.add_description("Automatically generated with Zappa")
         self.cf_api_resources = []
         self.cf_parameters = {}
 


### PR DESCRIPTION
## Description
Error trying to deploy Django on AWS lambda. (add_description() does not exist on Template").
I removed this line, and added the description to the Template constructor.
I'm using Django 3.2.5 and Zappa 0.53.0.

## GitHub Issues
I didn't find discussions in the forums.

