### PR TITLE
Enhance handling of text response - support more text minetypes and subtypes.

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -587,6 +587,13 @@ class LambdaHandler:
                             settings.BINARY_SUPPORT
                             and not response.mimetype.startswith("text/")
                             and response.mimetype != "application/json"
+                            and response.mimetype != "application/javascript"
+                            and response.mimetype != "application/ecmascript"
+                            and response.mimetype != "application/xml"
+                            and response.mimetype != "application/xml-external-parsed-entity"
+                            and response.mimetype != "application/xml-dtd"
+                            and response.mimetype != "image/svg+xml"
+                            and not (response.mimetype.startswith("application/") and response.mimetype.endswith("+xml"))
                         ):
                             zappa_returndict["body"] = base64.b64encode(
                                 response.data


### PR DESCRIPTION
## Description
Currently, minetypes starts with "text/" and "application/json" are handled as text responses from the WSGI server.
However, there are more minetypes that should be returned as text, not binary.

This PR adds support for the following minetypes to be treated as text.

* RFC 4627 (currently supported)
	* application/json
* RFC 4329 (by this PR)
	* application/javascript
	* application/ecmascript
* RFC 3023 (by this PR)
	* application/xml
	* application/xml-external-parsed-entity
	* application/xml-dtd  
	* image/svg+xml
	* specified by pattern "application/*+xml" including (but not limited to):
		* application/mathml+xml
		* application/xslt+xml
		* application/rdf+xml
		* application/atom+xml (ref: RFC 5023)
		* application/atomcat+xml (ref: RFC 5023)
		* application/atomsvc+xml (ref: RFC 5023)
		* application/beep+xml (ref: RFC 3080)
		* application/rss+xml
		* application/vnd.google-earth.kml+xml
		* application/vnd.irepository.package+xml
		* application/vnd.mozilla.xul+xml
		* application/vnd.pwg-xhtml-print+xml	　
		* application/xaml+xml
		* application/xhtml+xml

## GitHub Issues
https://github.com/zappa/Zappa/issues/1021

