### PR TITLE
Automatically Gzip Responses

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -481,6 +481,7 @@ class Zappa:
         zappa_things = [
             z for z in os.listdir(current_site_packages_dir) if z.lower()[:5] == "zappa"
         ]
+
         for z in zappa_things:
             copytree(
                 os.path.join(current_site_packages_dir, z),


### PR DESCRIPTION
Automatically gzip responses if the base64 encoded response is smaller.

Issue: https://github.com/zappa/Zappa/issues/1027

I have this deployed in production and it works well.

This will fail if a client doesn't support gzip compression. This isn't an issue if your app is behind CloudFront.

<!--


Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/zappa/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.6**, **Python 3.7** and **Python 3.8** ? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->
