### PR TITLE
Troposphere library "AttributeError" fix and python3.9 runtime support

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
 # These are supported funding model platforms
 
 github: ghostmaster-ai
-# custom: https://rzp.io/l/AWAZQ4Txq
+custom: https://rzp.io/l/zappa2

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,3 +2,4 @@
 
 github: ghostmaster-ai
 # custom: https://rzp.io/l/AWAZQ4Txq
+tidelift: pypi/zapp2

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,4 +2,3 @@
 
 github: ghostmaster-ai
 # custom: https://rzp.io/l/AWAZQ4Txq
-tidelift: pypi/zapp2

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+
+github: ghostmaster-ai
+custom: https://rzp.io/l/AWAZQ4Txq

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
 # These are supported funding model platforms
 
 github: ghostmaster-ai
-custom: https://rzp.io/l/AWAZQ4Txq
+# custom: https://rzp.io/l/AWAZQ4Txq

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,71 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    - cron: '38 0 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
+        # Learn more:
+        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## Zappa2 - This project was originally maintained by zappa
+Since the deprication of zappa by the original maintainers it is now maintained here.
+
+<form><script src="https://checkout.razorpay.com/v1/payment-button.js" data-payment_button_id="pl_I0ndeTw7Pij1dY" async> </script> </form>
+
+<hr />
+
 <p align="center">
   <img src="http://i.imgur.com/oePnHJn.jpg" alt="Zappa Rocks!"/>
 </p>

--- a/README.md
+++ b/README.md
@@ -11,12 +11,7 @@ Since the deprication of Zappa by the original maintainers it is now maintained 
 
 ## Zappa - Serverless Python
 
-[![Build Status](https://travis-ci.org/zappa/Zappa.svg)](https://travis-ci.org/zappa/Zappa)
-[![Coverage](https://img.shields.io/coveralls/zappa/Zappa.svg)](https://coveralls.io/github/zappa/Zappa)
-[![PyPI](https://img.shields.io/pypi/v/Zappa.svg)](https://pypi.python.org/pypi/zappa)
-[![Slack](https://img.shields.io/badge/chat-slack-ff69b4.svg)](https://zappateam.slack.com/)
-[![Gun.io](https://img.shields.io/badge/made%20by-gun.io-blue.svg)](https://gun.io/)
-[![Patreon](https://img.shields.io/badge/support-patreon-brightgreen.svg)](https://patreon.com/zappa)
+[![PyPI](https://img.shields.io/pypi/v/Zappa.svg)](https://pypi.python.org/pypi/zappa2)
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/README.md
+++ b/README.md
@@ -1451,7 +1451,6 @@ apigateway_resource_policy.json:
 * [Using Django-Zappa, Part 1](https://serverlesscode.com/post/zappa-wsgi-for-python/).
 * [Using Django-Zappa, Part 2: VPCs](https://serverlesscode.com/post/zappa-wsgi-for-python-pt-2/).
 * [Building Serverless Microservices with Zappa and Flask](https://gun.io/blog/serverless-microservices-with-zappa-and-flask/)
-* [Zappa で Hello World するまで (Japanese)](http://qiita.com/satoshi_iwashita/items/505492193317819772c7)
 * [How to Deploy Zappa with CloudFront, RDS and VPC](https://jinwright.net/how-deploy-serverless-wsgi-app-using-zappa/)
 * [Secure 'Serverless' File Uploads with AWS Lambda, S3, and Zappa](http://blog.stratospark.com/secure-serverless-file-uploads-with-aws-lambda-s3-zappa.html)
 * [Deploy a Serverless WSGI App using Zappa, CloudFront, RDS, and VPC](https://docs.google.com/presentation/d/1aYeOMgQl4V_fFgT5VNoycdXtob1v6xVUWlyxoTEiTw0/edit#slide=id.p)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Zappa2 - This project was originally maintained by zappa
 Since the deprication of Zappa by the original maintainers it is now maintained here.
 
-### We rely on your donation so if you can pls sponsor this project using the sponsorship link.
+#### We rely on your donation so if you can, please sponsor this project using the sponsorship link.
 
 <hr />
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Zappa2 - This project was originally maintained by zappa
-Since the deprication of zappa by the original maintainers it is now maintained here.
+Since the deprication of Zappa by the original maintainers it is now maintained here.
 
-<form><script src="https://checkout.razorpay.com/v1/payment-button.js" data-payment_button_id="pl_I0ndeTw7Pij1dY" async> </script> </form>
+### We rely on your donation so if you can pls sponsor this project using the sponsorship link.
 
 <hr />
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,7 +76,7 @@ tqdm==4.59.0
     # via -r requirements.in
 troposphere==2.7.0
     # via -r requirements.in
-urllib3==1.26.4
+urllib3==1.26.5
     # via
     #   botocore
     #   requests

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@ with open(os.path.join(os.path.dirname(__file__), 'test_requirements.in')) as f:
     test_required = f.read().splitlines()
 
 setup(
-    name='zappa',
+    name='zappa2',
     version=__version__,
-    packages=['zappa'],
+    packages=['zappa2'],
     install_requires=required,
     tests_require=test_required,
     test_suite='nose.collector',
@@ -25,7 +25,7 @@ setup(
     description='Server-less Python Web Services for AWS Lambda and API Gateway',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    url='https://github.com/zappa/Zappa',
+    url='https://github.com/ghostmaster-ai/Zappa2',
     author='Rich Jones',
     author_email='rich@openwatch.net',
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
+    project_urls={
+        'Funding': 'https://rzp.io/l/zappa2',
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from io import open
 from zappa import __version__
 
-with open('README.md') as readme_file:
+with open('README.md', "r", encoding="utf-8") as readme_file:
     long_description = readme_file.read()
 
 with open(os.path.join(os.path.dirname(__file__), 'requirements.in')) as f:
@@ -16,7 +16,7 @@ with open(os.path.join(os.path.dirname(__file__), 'test_requirements.in')) as f:
 setup(
     name='zappa2',
     version=__version__,
-    packages=['zappa2'],
+    packages=['zappa'],
     install_requires=required,
     tests_require=test_required,
     test_suite='nose.collector',
@@ -26,8 +26,8 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/ghostmaster-ai/Zappa2',
-    author='Rich Jones',
-    author_email='rich@openwatch.net',
+    author='ghostmaster-ai',
+    author_email='spranav97@hotmail.com',
     entry_points={
         'console_scripts': [
             'zappa=zappa.cli:handle',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -91,7 +91,7 @@ typing-extensions==3.10.0.0
     # via
     #   django-stubs
     #   mypy
-urllib3==1.26.4
+urllib3==1.26.5
     # via requests
 werkzeug==0.16.1
     # via flask

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -24,7 +24,7 @@ coverage==5.5
     # via coveralls
 coveralls==3.0.1
     # via -r test_requirements.in
-django==3.1.7
+django==3.1.13
     # via
     #   -r test_requirements.in
     #   django-stubs

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,60 +6,39 @@
 #
 appdirs==1.4.4
     # via black
-argcomplete==1.12.2
-    # via -r requirements.in
 asgiref==3.3.1
     # via django
 black==21.5b1
     # via -r test_requirements.in
 boto3-stubs==1.17.78
     # via -r test_requirements.in
-boto3==1.17.44
-    # via
-    #   -r requirements.in
-    #   kappa
-botocore==1.20.44
-    # via
-    #   boto3
-    #   s3transfer
 certifi==2020.12.5
     # via requests
-cfn-flip==1.2.3
-    # via troposphere
 chardet==4.0.0
     # via requests
 click==7.1.2
     # via
     #   black
-    #   cfn-flip
     #   flask
-    #   kappa
-    #   pip-tools
 coverage==5.5
     # via coveralls
 coveralls==3.0.1
-    # via -r test_requirements.in
-django-stubs-ext==0.2.0
-    # via django-stubs
-django-stubs==1.8.0
     # via -r test_requirements.in
 django==3.1.7
     # via
     #   -r test_requirements.in
     #   django-stubs
     #   django-stubs-ext
+django-stubs==1.8.0
+    # via -r test_requirements.in
+django-stubs-ext==0.2.0
+    # via django-stubs
 docopt==0.6.2
     # via coveralls
-durationpy==0.5
-    # via -r requirements.in
 flake8==3.9.0
     # via -r test_requirements.in
 flask==1.1.2
     # via -r test_requirements.in
-future==0.18.2
-    # via -r requirements.in
-hjson==3.0.2
-    # via -r requirements.in
 idna==2.10
     # via requests
 isort==5.8.0
@@ -68,86 +47,44 @@ itsdangerous==1.1.0
     # via flask
 jinja2==2.11.3
     # via flask
-jmespath==0.10.0
-    # via
-    #   -r requirements.in
-    #   boto3
-    #   botocore
-kappa==0.6.0
-    # via -r requirements.in
 markupsafe==1.1.1
     # via jinja2
 mccabe==0.6.1
     # via flake8
 mock==4.0.3
     # via -r test_requirements.in
-mypy-extensions==0.4.3
-    # via
-    #   black
-    #   mypy
 mypy==0.812
     # via
     #   -r test_requirements.in
     #   django-stubs
-nose-timer==1.0.1
-    # via -r test_requirements.in
+mypy-extensions==0.4.3
+    # via
+    #   black
+    #   mypy
 nose==1.3.7
     # via
     #   -r test_requirements.in
     #   nose-timer
+nose-timer==1.0.1
+    # via -r test_requirements.in
 pathspec==0.8.1
     # via black
-pep517==0.10.0
-    # via pip-tools
-pip-tools==6.0.1
-    # via -r requirements.in
 placebo==0.9.0
-    # via
-    #   -r test_requirements.in
-    #   kappa
+    # via -r test_requirements.in
 pycodestyle==2.7.0
     # via flake8
 pyflakes==2.3.1
     # via flake8
-python-dateutil==2.8.1
-    # via
-    #   -r requirements.in
-    #   botocore
-python-slugify==4.0.1
-    # via -r requirements.in
 pytz==2021.1
     # via django
-pyyaml==5.4.1
-    # via
-    #   -r requirements.in
-    #   cfn-flip
-    #   kappa
 regex==2021.4.4
     # via black
 requests==2.25.1
-    # via
-    #   -r requirements.in
-    #   coveralls
-s3transfer==0.3.6
-    # via boto3
-six==1.15.0
-    # via
-    #   -r requirements.in
-    #   cfn-flip
-    #   python-dateutil
-sqlparse==0.4.1
+    # via coveralls
+sqlparse==0.4.2
     # via django
-text-unidecode==1.3
-    # via python-slugify
 toml==0.10.2
-    # via
-    #   -r requirements.in
-    #   black
-    #   pep517
-tqdm==4.59.0
-    # via -r requirements.in
-troposphere==2.7.0
-    # via -r requirements.in
+    # via black
 typed-ast==1.4.3
     # via mypy
 typing-extensions==3.10.0.0
@@ -155,17 +92,6 @@ typing-extensions==3.10.0.0
     #   django-stubs
     #   mypy
 urllib3==1.26.4
-    # via
-    #   botocore
-    #   requests
+    # via requests
 werkzeug==0.16.1
-    # via
-    #   -r requirements.in
-    #   flask
-wheel==0.36.2
-    # via -r requirements.in
-wsgi-request-logger==0.4.6
-    # via -r requirements.in
-
-# The following packages are considered to be unsafe in a requirements file:
-# pip
+    # via flask

--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-SUPPORTED_VERSIONS = [(3, 6), (3, 7), (3, 8)]
+SUPPORTED_VERSIONS = [(3, 6), (3, 7), (3, 8), (3, 9)]
 
 if sys.version_info[:2] not in SUPPORTED_VERSIONS:
     formatted_supported_versions = [

--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -13,4 +13,4 @@ if sys.version_info[:2] not in SUPPORTED_VERSIONS:
     )
     raise RuntimeError(err_msg)
 
-__version__ = "0.53.3"
+__version__ = "0.53.4"

--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -13,4 +13,4 @@ if sys.version_info[:2] not in SUPPORTED_VERSIONS:
     )
     raise RuntimeError(err_msg)
 
-__version__ = "0.53.1"
+__version__ = "0.53.2"

--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -13,4 +13,4 @@ if sys.version_info[:2] not in SUPPORTED_VERSIONS:
     )
     raise RuntimeError(err_msg)
 
-__version__ = "0.53.0"
+__version__ = "0.53.1"

--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -13,4 +13,4 @@ if sys.version_info[:2] not in SUPPORTED_VERSIONS:
     )
     raise RuntimeError(err_msg)
 
-__version__ = "0.53.2"
+__version__ = "0.53.3"

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -206,7 +206,7 @@ class ZappaCLI:
             "-v",
             "--version",
             action="version",
-            version=pkg_resources.get_distribution("zappa").version,
+            version=pkg_resources.get_distribution("zappa2").version,
             help="Print the zappa version",
         )
         parser.add_argument(

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2446,7 +2446,7 @@ class ZappaCLI:
         Print a warning if there's a new Zappa version available.
         """
         try:
-            version = pkg_resources.require("zappa")[0].version
+            version = pkg_resources.require("zappa2")[0].version
             updateable = check_new_version_available(version)
             if updateable:
                 click.echo(

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2414,7 +2414,7 @@ class Zappa:
 
         # build a fresh template
         self.cf_template = troposphere.Template()
-        self.cf_template.add_description("Automatically generated with Zappa")
+        self.cf_template.set_description("Automatically generated with Zappa")
         self.cf_api_resources = []
         self.cf_parameters = {}
 

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2964,6 +2964,9 @@ class Zappa:
         logger.debug(
             "Adding new permission to invoke Lambda function: {}".format(lambda_name)
         )
+
+        account_id: str = self.sts_client.get_caller_identity().get('Account')
+
         permission_response = self.lambda_client.add_permission(
             FunctionName=lambda_name,
             StatementId="".join(
@@ -2972,6 +2975,12 @@ class Zappa:
             Action="lambda:InvokeFunction",
             Principal=principal,
             SourceArn=source_arn,
+            # The SourceAccount argument ensures that only the specified AWS account can invoke the lambda function.
+            # This prevents a security issue where if a lambda is triggered off of s3 bucket events and the bucket is
+            # deleted, another AWS account can create a bucket with the same name and potentially trigger the original
+            # lambda function, since bucket names are global.
+            # https://github.com/zappa/Zappa/issues/1039
+            SourceAccount=account_id
         )
 
         if permission_response["ResponseMetadata"]["HTTPStatusCode"] != 201:


### PR DESCRIPTION
## Description
zappa/core.py
method "add_description" in core.py line 2417 doesn't exists in the latest troposphere library, method "set_description" takes it's place. This change allows for "zappa deploy" and "zappa update" without errors.


## GitHub Issues
https://github.com/zappa/Zappa/issues/1016
https://github.com/zappa/Zappa/issues/1002
https://github.com/zappa/Zappa/issues/1000