### PR TITLE
Add Support for Graviton 2 / ARM `Architectures`

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,6 +834,7 @@ to change Zappa's behavior. Use these at your own risk!
         "assume_policy": "my_assume_policy.json", // optional, IAM assume policy JSON file
         "attach_policy": "my_attach_policy.json", // optional, IAM attach policy JSON file
         "apigateway_policy": "my_apigateway_policy.json", // optional, API Gateway resource policy JSON file
+        "architectures": "arm64", // optional, Set Lambda Architecture, defaults to x86_64. For Graviton 2 use: arm64
         "async_source": "sns", // Source of async tasks. Defaults to "lambda"
         "async_resources": true, // Create the SNS topic and DynamoDB table to use. Defaults to true.
         "async_response_table": "your_dynamodb_table_name",  // the DynamoDB table name to use for captured async responses; defaults to None (can't capture)

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -126,6 +126,7 @@ class ZappaCLI:
     context_header_mappings = None
     tags = []
     layers = None
+    architectures = []
 
     stage_name_env_pattern = re.compile("^[a-zA-Z0-9_]+$")
 
@@ -911,6 +912,7 @@ class ZappaCLI:
                 use_alb=self.use_alb,
                 layers=self.layers,
                 concurrency=self.lambda_concurrency,
+                architectures=self.architectures,
             )
             kwargs["function_name"] = self.lambda_name
             if docker_image_uri:
@@ -1136,6 +1138,7 @@ class ZappaCLI:
             function_name=self.lambda_name,
             num_revisions=self.num_retained_versions,
             concurrency=self.lambda_concurrency,
+            architectures=self.architectures,
         )
         if docker_image_uri:
             kwargs["docker_image_uri"] = docker_image_uri
@@ -1172,6 +1175,7 @@ class ZappaCLI:
             aws_kms_key_arn=self.aws_kms_key_arn,
             layers=self.layers,
             wait=False,
+            architectures=self.architectures,
         )
 
         # Finally, delete the local copy our zip package
@@ -2537,6 +2541,7 @@ class ZappaCLI:
         self.num_retained_versions = self.stage_config.get(
             "num_retained_versions", None
         )
+        self.architectures = [self.stage_config.get("architectures", "x86_64")]
 
         # Check for valid values of num_retained_versions
         if (
@@ -2608,6 +2613,9 @@ class ZappaCLI:
         # Additional tags
         self.tags = self.stage_config.get("tags", {})
 
+        # Architectures
+        self.architectures = [self.stage_config.get("architectures", "x86_64")]
+
         desired_role_name = self.lambda_name + "-ZappaLambdaExecutionRole"
         self.zappa = Zappa(
             boto_session=session,
@@ -2620,6 +2628,7 @@ class ZappaCLI:
             tags=self.tags,
             endpoint_urls=self.stage_config.get("aws_endpoint_urls", {}),
             xray_tracing=self.xray_tracing,
+            architectures=self.architectures
         )
 
         for setting in CUSTOM_SETTINGS:

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -965,7 +965,7 @@ class Zappa:
         else:
             # Check if we already have a cached copy
             wheel_name = re.sub("[^\w\d.]+", "_", package_name, re.UNICODE)
-            wheel_file = f"{wheel_name}-{package_version}-*_x86_64.whl"
+            wheel_file = f"{wheel_name}-{package_version}-*_{self.architectures[0]}.whl"
             wheel_path = os.path.join(cached_wheels_dir, wheel_file)
 
             for pathname in glob.iglob(wheel_path):


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/zappa/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.6**, **Python 3.7** and **Python 3.8** ? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
This PR adds support for Graviton 2 / ARM64 Lambda's. It adds a new `architectures` configuration option, which defaults to `x86_64`. This parameter is also used for correct architecture wheel selection.

This is my first submission to Zappa, so please do CR and feedback anything I might have missed, or need to do.

AWS API [Docs](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#API_CreateFunction_RequestSyntax)

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
Resolves: https://github.com/zappa/Zappa/issues/1051

