### PR TITLE
Increase lambda client read timeout to 15 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,8 +420,6 @@ Commands which require direct user input, such as `createsuperuser`, should be [
 
 For more Django integration, take a look at the [zappa-django-utils](https://github.com/Miserlou/zappa-django-utils) project.
 
-_(Please note that commands which take over 30 seconds to execute may time-out preventing output from being returned - but the command may continue to run. See [this related issue](https://github.com/Miserlou/Zappa/issues/205#issuecomment-236391248) for a work-around.)_
-
 ### SSL Certification
 
 Zappa can be deployed to custom domain names and subdomains with custom SSL certificates, Let's Encrypt certificates, and [AWS Certificate Manager](https://aws.amazon.com/certificate-manager/) (ACM) certificates.

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -331,13 +331,14 @@ class Zappa:
         # Some common invocations, such as DB migrations,
         # can take longer than the default.
 
-        # Note that this is set to 300s, but if connected to
-        # APIGW, Lambda will max out at 30s.
+        # Config used for direct invocations of Lambda functions from the Zappa CLI.
+        # Note that the maximum configurable Lambda function execution time (15 minutes)
+        # is longer than the maximum timeout configurable in API Gateway (30 seconds).
         # Related: https://github.com/Miserlou/Zappa/issues/205
         long_config_dict = {
             "region_name": aws_region,
             "connect_timeout": 5,
-            "read_timeout": 300,
+            "read_timeout": 900,
         }
         long_config = botocore.client.Config(**long_config_dict)
 


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/zappa/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.6**, **Python 3.7** and **Python 3.8** ? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
This change increases the read timeout on the Zappa CLI's Lambda client to 15 minutes.

As of 2018, Lambda functions [can be configured][1] to run for up to 15 minutes per execution, but the configuration for the Zappa CLI's Lambda client had its timeout set to 5 minutes. This meant that the Lambda client would time out waiting for a response from a long-running invocation (e.g. a Django management command that runs for more than 5 minutes) while the actual function could continue to execute for up to 15 minutes, depending on its configuration.

I believe the comment in the README regarding the 30-second API gateway timeout's effect on long-running management command invocations is incorrect or misleading. Django management commands invoked via `zappa manage` execute the Lambda function directly using a boto3 Lambda client (in the `Zappa.invoke_lambda_function` method), so the API Gateway timeout should not affect these invocations at all.

[1]: https://aws.amazon.com/about-aws/whats-new/2018/10/aws-lambda-supports-functions-that-can-run-up-to-15-minutes
## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
Fixes #1064.
