### PR TITLE
Unpin 'Werkzeug' from v0.x

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,8 +15,7 @@ six
 toml
 tqdm
 troposphere>=3.0
-# See https://github.com/Miserlou/Zappa/issues/2036
-Werkzeug<1.0
+Werkzeug
 wheel
 wsgi-request-logger
 pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,23 +4,23 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-argcomplete==1.12.2
+argcomplete==1.12.3
     # via -r requirements.in
-boto3==1.17.44
+boto3==1.19.11
     # via
     #   -r requirements.in
     #   kappa
-botocore==1.20.44
+botocore==1.22.11
     # via
     #   boto3
     #   s3transfer
-certifi==2020.12.5
+certifi==2021.10.8
     # via requests
-cfn-flip==1.2.3
+cfn-flip==1.3.0
     # via troposphere
-chardet==4.0.0
+charset-normalizer==2.0.7
     # via requests
-click==7.1.2
+click==8.0.3
     # via
     #   cfn-flip
     #   kappa
@@ -31,7 +31,7 @@ future==0.18.2
     # via -r requirements.in
 hjson==3.0.2
     # via -r requirements.in
-idna==2.10
+idna==3.3
     # via requests
 jmespath==0.10.0
     # via
@@ -40,28 +40,28 @@ jmespath==0.10.0
     #   botocore
 kappa==0.6.0
     # via -r requirements.in
-pep517==0.10.0
+pep517==0.12.0
     # via pip-tools
-pip-tools==6.0.1
+pip-tools==6.4.0
     # via -r requirements.in
-placebo==0.9.0
+placebo==0.10.0
     # via kappa
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   -r requirements.in
     #   botocore
-python-slugify==4.0.1
+python-slugify==5.0.2
     # via -r requirements.in
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -r requirements.in
     #   cfn-flip
     #   kappa
-requests==2.25.1
+requests==2.26.0
     # via -r requirements.in
-s3transfer==0.3.6
+s3transfer==0.5.0
     # via boto3
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements.in
     #   cfn-flip
@@ -69,23 +69,26 @@ six==1.15.0
 text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
-    # via
-    #   -r requirements.in
-    #   pep517
-tqdm==4.59.0
     # via -r requirements.in
-troposphere==3.0.2
+tomli==1.2.2
+    # via pep517
+tqdm==4.62.3
     # via -r requirements.in
-urllib3==1.26.4
+troposphere==3.1.0
+    # via -r requirements.in
+urllib3==1.26.7
     # via
     #   botocore
     #   requests
-werkzeug==0.16.1
+werkzeug==2.0.2
     # via -r requirements.in
-wheel==0.36.2
-    # via -r requirements.in
+wheel==0.37.0
+    # via
+    #   -r requirements.in
+    #   pip-tools
 wsgi-request-logger==0.4.6
     # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip
+# setuptools


### PR DESCRIPTION
## Description
Similar to #1059, but only removes pin to `Werkzeug<1.0` from `requirements.in` and updates `requirements.txt`.  Doing the same for test requirements currently causes issues with tests, as seen in #1059.

Going with a more targeted approach like this may be warranted as it would allow users to use `Werkzeug==2.0.2` alongside `Zappa`, which resolves [PVE-2021-42050](https://github.com/pyupio/safety-db/commit/a71c7c851fcc3ff001d4e0aa379ca6390184a5df#diff-674fdcad879dee1d5570c68e560a6678eb78df68003a7c834532af09c4f264cbR34741-R34749).  This also allows `Zappa` to coexist peacefully with `Flask 2` (#1066).

## GitHub Issues
Closes #1066  
Closes #1038
