### PR TITLE
Release 'Zappa' v0.54.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zappa Changelog
 
+## 0.54.1
+* Increase Lambda client read timeout to 15m (#1065)
+* Unpin `Werkzeug` from `v0.x` (#1067)
+
 ## 0.54.0
 * Pin troposphere version and update to 3.x (#1029)
 * Relax stage name restrictions when not using apigateway (#993)

--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -13,4 +13,4 @@ if sys.version_info[:2] not in SUPPORTED_VERSIONS:
     )
     raise RuntimeError(err_msg)
 
-__version__ = "0.54.0"
+__version__ = "0.54.1"


### PR DESCRIPTION
## Description
Updates version number to `v0.54.1` and changelog to reflect new changes since `v0.54.0`.  See individual PRs mentioned in the changelog for more details.

## GitHub Issues
#1065  
#1067  

