### PR TITLE
Don't install dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,18 +7,10 @@ from zappa import __version__
 with open('README.md') as readme_file:
     long_description = readme_file.read()
 
-with open(os.path.join(os.path.dirname(__file__), 'requirements.in')) as f:
-    required = f.read().splitlines()
-
-with open(os.path.join(os.path.dirname(__file__), 'test_requirements.in')) as f:
-    test_required = f.read().splitlines()
-
 setup(
     name='zappa',
     version=__version__,
     packages=['zappa'],
-    install_requires=required,
-    tests_require=test_required,
     test_suite='nose.collector',
     include_package_data=True,
     license='MIT License',


### PR DESCRIPTION
Allows the project using Zappa to declare Zappa dependencies themselves to avoid getting conflicts with their own deps.