### PR TITLE
Move from CNAME to Alias Route53 records

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1858,7 +1858,7 @@ class TestZappa(unittest.TestCase):
             "HostedZones": [{"Id": "somezone"}],
         }
         zappa_core.route53.list_resource_record_sets.return_value = {
-            "ResourceRecordSets": [{"Type": "CNAME", "Name": "test_domain1"}]
+            "ResourceRecordSets": [{"Type": "A", "Name": "test_domain1"}]
         }
 
         record = zappa_core.get_domain_name("test_domain")

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2655,36 +2655,20 @@ class Zappa:
         """
         zone_id = self.get_hosted_zone_id_for_domain(domain_name)
 
-        is_apex = (
-            self.route53.get_hosted_zone(Id=zone_id)["HostedZone"]["Name"][:-1]
-            == domain_name
-        )
-        if is_apex:
-            record_set = {
-                "Name": domain_name,
-                "Type": "A",
-                "AliasTarget": {
-                    "HostedZoneId": "Z2FDTNDATAQYW2",  # This is a magic value that means "CloudFront"
-                    "DNSName": dns_name,
-                    "EvaluateTargetHealth": False,
-                },
-            }
-        else:
-            record_set = {
-                "Name": domain_name,
-                "Type": "CNAME",
-                "ResourceRecords": [{"Value": dns_name}],
-                "TTL": 60,
-            }
+        record_set = {
+            "Name": domain_name,
+            "Type": "A",
+            "AliasTarget": {
+                "HostedZoneId": "Z2FDTNDATAQYW2",  # This is a magic value that means "CloudFront"
+                "DNSName": dns_name,
+                "EvaluateTargetHealth": False,
+            },
+        }
 
         # Related: https://github.com/boto/boto3/issues/157
         # and: http://docs.aws.amazon.com/Route53/latest/APIReference/CreateAliasRRSAPI.html
         # and policy: https://spin.atomicobject.com/2016/04/28/route-53-hosted-zone-managment/
-        # pure_zone_id = zone_id.split('/hostedzone/')[1]
 
-        # XXX: ClientError: An error occurred (InvalidChangeBatch) when calling the ChangeResourceRecordSets operation:
-        # Tried to create an alias that targets d1awfeji80d0k2.cloudfront.net., type A in zone Z1XWOQP59BYF6Z,
-        # but the alias target name does not lie within the target zone
         response = self.route53.change_resource_record_sets(
             HostedZoneId=zone_id,
             ChangeBatch={


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/zappa/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.6**, **Python 3.7** and **Python 3.8** ? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
This PR removes code related to CNAME records for Route53-hosted custom domains, using only A Alias records when upserting.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
https://github.com/zappa/Zappa/issues/1073
