### PR TITLE
Add Compressed Text Support

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -584,6 +584,7 @@ class LambdaHandler:
 
                     if response.data:
                         content_encoding = response.headers.get("Content-Encoding", None)
+                        print(content_encoding)
                         binary_encodings = ("gzip", "compress", "deflate", "br")
                         if (
                             settings.BINARY_SUPPORT

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -583,11 +583,18 @@ class LambdaHandler:
                         )
 
                     if response.data:
+                        content_encoding = response.headers.get("Content-Encoding", None)
+                        binary_encodings = ("gzip", "compress", "deflate", "br")
                         if (
                             settings.BINARY_SUPPORT
                             and not response.mimetype.startswith("text/")
                             and response.mimetype != "application/json"
                         ):
+                            zappa_returndict["body"] = base64.b64encode(
+                                response.data
+                            ).decode("utf-8")
+                            zappa_returndict["isBase64Encoded"] = True
+                        elif settings.BINARY_SUPPORT and content_encoding in binary_encodings:
                             zappa_returndict["body"] = base64.b64encode(
                                 response.data
                             ).decode("utf-8")

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -583,8 +583,6 @@ class LambdaHandler:
                         )
 
                     if response.data:
-                        content_encoding = response.headers.get("Content-Encoding", None)
-                        binary_encodings = ("gzip", "compress", "deflate", "br")
                         if (
                             settings.BINARY_SUPPORT
                             and not response.mimetype.startswith("text/")
@@ -594,7 +592,7 @@ class LambdaHandler:
                                 response.data
                             ).decode("utf-8")
                             zappa_returndict["isBase64Encoded"] = True
-                        elif settings.BINARY_SUPPORT and content_encoding in binary_encodings:
+                        elif settings.BINARY_SUPPORT and response.headers.get("Content-Encoding", None):
                             zappa_returndict["body"] = base64.b64encode(
                                 response.data
                             ).decode("utf-8")

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -584,12 +584,11 @@ class LambdaHandler:
 
                     if response.data:
                         content_encoding = response.headers.get("Content-Encoding", None)
-                        print(content_encoding)
                         binary_encodings = ("gzip", "compress", "deflate", "br")
                         if (
                             settings.BINARY_SUPPORT
                             and not response.mimetype.startswith("text/")
-                            and response.mimetype not in ("application/json", "application/font-woff")
+                            and response.mimetype != "application/json"
                         ):
                             zappa_returndict["body"] = base64.b64encode(
                                 response.data

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -588,7 +588,7 @@ class LambdaHandler:
                         if (
                             settings.BINARY_SUPPORT
                             and not response.mimetype.startswith("text/")
-                            and response.mimetype != "application/json"
+                            and response.mimetype not in ("application/json", "application/font-woff")
                         ):
                             zappa_returndict["body"] = base64.b64encode(
                                 response.data


### PR DESCRIPTION
## Description

Currently, in version 0.54.1, when compressed text is sent in response, zappa throws the following exception:

```
{'message': 
'An uncaught exception happened while servicing this request. You can investigate this with the `zappa tail` command.', 'traceback': 
['Traceback (most recent call last):\\n', 
'  File \"/var/task/handler.py\", line 596, in handler\\n
    zappa_returndict[\"body\"] = response.get_data(as_text=True)\\n', 
'  File \"/var/task/werkzeug/wrappers/response.py\", 
line 313, in get_data\\n    return rv.decode(self.charset)\\n', 
\"UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte\\n\
"]}
```


This is intended to allow BINARY and text by making use of Content-Encoding header in the response.

When using whitenoise for caching, which provides compression, binary types may include mimetypes, "text/", "application/json":

```
response.mimetype.startswith("text/")
response.mimetype == "application/json"
```

Assuming that Content-Encoding will be set (as whitenoise apparently does) this allows compression to be applied to assets which have mimetypes "text/" and "application/json", while allowing for uncompressed "text/" and "application/json" still to be served.

About Content-Encoding:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding

Not sure if this works for all use cases, but it currently appears to work for my workcase where whitenoise is performing compression of text/json files intended for caching, while still allowing text for html.


## GitHub Issues

https://github.com/zappa/Zappa/issues/908
