### PR TITLE
document how to configure eventbridge events

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,20 @@ def your_recurring_function(event, context):
 
 ```
 
+[EventBridge] AWS can configure filtered events using AWS Event Bridge.   Zappa allows for a default handler for these configured like so
+```javascript
+       "events": [
+            {
+                "function": "your_module.your_default_event_handler", // The function to execute
+                "event_source": {
+                    "arn": "arn:aws:events:REGION:ACCOUNT_ID:event-bus/default/default_event_handler", 
+                    "pattern": '{"source": ["aws.glue", "my.event"]}', // Pattern as defined https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html
+                    "events": ["default"] // Default handler
+                    }  
+            }
+       ]
+```
+
 
 You can find more [example event sources here](http://docs.aws.amazon.com/lambda/latest/dg/eventsources.html).
 

--- a/tests/tests_placebo.py
+++ b/tests/tests_placebo.py
@@ -523,7 +523,7 @@ class TestZappa(unittest.TestCase):
         # Sanity. This should fail.
         try:
             es = add_event_source(
-                event_source, "blah:blah:blah:blah", "test_settings.callback", session
+                event_source, "blah:blah:blah:blah", "test_settings.callback", "test-function", session
             )
             self.fail("Success should have failed.")
         except ValueError:
@@ -534,6 +534,7 @@ class TestZappa(unittest.TestCase):
             event_source,
             "lambda:lambda:lambda:lambda",
             "test_settings.callback",
+            "test-function",
             session,
             dry=True,
         )
@@ -541,6 +542,7 @@ class TestZappa(unittest.TestCase):
             event_source,
             "lambda:lambda:lambda:lambda",
             "test_settings.callback",
+            "test-function",
             session,
             dry=True,
         )

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -3136,7 +3136,7 @@ class Zappa:
                     svc = service
 
                 rule_response = add_event_source(
-                    event_source, lambda_arn, function, self.boto_session
+                    event_source, lambda_arn, function, lambda_name, self.boto_session
                 )
 
                 if rule_response == "successful":
@@ -3288,7 +3288,7 @@ class Zappa:
             # update or zappa schedule.
             if service not in excluded_source_services:
                 remove_event_source(
-                    event_source, lambda_arn, function, self.boto_session
+                    event_source, lambda_arn, function, lambda_name, self.boto_session
                 )
                 print(
                     "Removed event {}{}.".format(
@@ -3323,6 +3323,7 @@ class Zappa:
             event_source={"arn": topic_arn, "events": ["sns:Publish"]},
             lambda_arn=lambda_arn,
             target_function="zappa.asynchronous.route_task",
+            lambda_name=lambda_name,
             boto_session=self.boto_session,
         )
         return topic_arn


### PR DESCRIPTION
## Description

Fix the handling of EventBridge events to allow the registration of arbitrary patterns using event bridge to enable Zappa to trigger events on anything from AWS.
