### PR TITLE
Update handler to be global if INSTANTIATE_LAMBDA_HANDLER_ON_IMPORT=True

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -248,9 +248,7 @@ class LambdaHandler:
 
     @classmethod
     def lambda_handler(cls, event, context):  # pragma: no cover
-        global handler
-        if not os.environ.get("INSTANTIATE_LAMBDA_HANDLER_ON_IMPORT"):
-            handler = cls()
+        handler = global_handler or cls()
         exception_handler = handler.settings.EXCEPTION_HANDLER
         try:
             return handler.handler(event, context)
@@ -667,5 +665,6 @@ def keep_warm_callback(event, context):
     # be triggered.
 
 
+global_handler = None
 if os.environ.get("INSTANTIATE_LAMBDA_HANDLER_ON_IMPORT"):
-    handler = LambdaHandler()
+    global_handler = LambdaHandler()

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -248,6 +248,7 @@ class LambdaHandler:
 
     @classmethod
     def lambda_handler(cls, event, context):  # pragma: no cover
+        global handler
         if not os.environ.get("INSTANTIATE_LAMBDA_HANDLER_ON_IMPORT"):
             handler = cls()
         exception_handler = handler.settings.EXCEPTION_HANDLER


### PR DESCRIPTION
INSTANTIATE_LAMBDA_HANDLER_ON_IMPORT was introduced in https://github.com/zappa/Zappa/pull/982 but I'm noticing an error `UnboundLocalError: local variable 'handler' referenced before assignment` if I set the env var, which I believe is because `handler` needs to be global.