### PR TITLE
@task should throw an error if def arguments are not json serializable, this will cause code to crash locally if it will crash when deployed to actual lambdas

### DIFF
--- a/zappa/asynchronous.py
+++ b/zappa/asynchronous.py
@@ -436,6 +436,12 @@ def task(*args, **kwargs):
                 When outside of Lambda, the func passed to @task is run and we
                 return the actual value.
             """
+            try:
+                json.dumps(args)
+                json.dumps(kwargs)
+            except (TypeError, OverflowError):
+                raise AsyncException("@task requires JSON serializable args and kwargs")
+
             lambda_function_name = lambda_function_name_arg or os.environ.get(
                 "AWS_LAMBDA_FUNCTION_NAME"
             )


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/zappa/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.6**, **Python 3.7** and **Python 3.8** ? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

