### PR TITLE
Added default fallback in case packagetype is not found.

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1405,7 +1405,7 @@ class Zappa:
             "TracingConfig": {"Mode": "Active" if self.xray_tracing else "PassThrough"},
         }
 
-        if lambda_aws_config["PackageType"] != "Image":
+        if lambda_aws_config.get("PackageType",None) != "Image":
             kwargs.update(
                 {
                     "Handler": handler,


### PR DESCRIPTION
Issue - https://github.com/zappa/Zappa/issues/1035
* package type is supposed to be not present in lambda configuration
* we should have a fallback not finding the Package_Type key