### PR TITLE
Add support for authorizer REQUEST type

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,19 +903,18 @@ to change Zappa's behavior. Use these at your own risk!
         "iam_authorization": false, // optional, use IAM to require request signing. Default false. Note that enabling this will override the authorizer configuration.
         "include": ["your_special_library_to_load_at_handler_init"], // load special libraries into PYTHONPATH at handler init that certain modules cannot find on path
         "authorizer": {
-            "type": "request", // Authorizer type, request or token (Default 'token')
+            "type": "REQUEST", // Authorizer type, REQUEST or TOKEN (Default 'TOKEN')
             "function": "your_module.your_auth_function", // Local function to run for token validation. For more information about the function see below.
             "arn": "arn:aws:lambda:<region>:<account_id>:function:<function_name>", // Existing Lambda function to run for token validation.
             "result_ttl": 300, // Optional. Default 300. The time-to-live (TTL) period, in seconds, that specifies how long API Gateway caches authorizer results. Currently, the maximum TTL value is 3600 seconds.
             "token_header": "Authorization", // Optional. Default 'Authorization'. The name of a custom authorization header containing the token that clients submit as part of their requests.
             "validation_expression": "^Bearer \\w+$", // Optional. A validation expression for the incoming token, specify a regular expression.
-            "identity_sources": { // Optional. Default to header 'Authorization'. The name of the custom request info destined for the authorizer.
+            "identity_sources": { // Optional. Default to { 'header' : 'Authorization'}. The names of the custom request expressions destined for the authorizer.
                 "header": "Authorization",
                 "query_string": "token",
-                "multi_value_query_string": "token",
                 "stage_variable": "test",
-                "context": "httpMethod",
-            }]
+                "context": "principalId",
+            }
         },
         "keep_warm": true, // Create CloudWatch events to keep the server warm. Default true. To remove, set to false and then `unschedule`.
         "keep_warm_expression": "rate(4 minutes)", // How often to execute the keep-warm, in cron and rate format. Default 4 minutes.

--- a/README.md
+++ b/README.md
@@ -909,7 +909,7 @@ to change Zappa's behavior. Use these at your own risk!
             "result_ttl": 300, // Optional. Default 300. The time-to-live (TTL) period, in seconds, that specifies how long API Gateway caches authorizer results. Currently, the maximum TTL value is 3600 seconds.
             "token_header": "Authorization", // Optional. Default 'Authorization'. The name of a custom authorization header containing the token that clients submit as part of their requests.
             "validation_expression": "^Bearer \\w+$", // Optional. A validation expression for the incoming token, specify a regular expression.
-            "identity_sources": { // Optional. Default to { 'header' : 'Authorization'}. The names of the custom request expressions destined for the authorizer.
+            "identity_sources": { // Optional. The names of the custom request expressions destined for the authorizer.
                 "header": "Authorization",
                 "query_string": "token",
                 "stage_variable": "test",

--- a/README.md
+++ b/README.md
@@ -903,11 +903,19 @@ to change Zappa's behavior. Use these at your own risk!
         "iam_authorization": false, // optional, use IAM to require request signing. Default false. Note that enabling this will override the authorizer configuration.
         "include": ["your_special_library_to_load_at_handler_init"], // load special libraries into PYTHONPATH at handler init that certain modules cannot find on path
         "authorizer": {
+            "type": "request", // Authorizer type, request or token (Default 'token')
             "function": "your_module.your_auth_function", // Local function to run for token validation. For more information about the function see below.
             "arn": "arn:aws:lambda:<region>:<account_id>:function:<function_name>", // Existing Lambda function to run for token validation.
             "result_ttl": 300, // Optional. Default 300. The time-to-live (TTL) period, in seconds, that specifies how long API Gateway caches authorizer results. Currently, the maximum TTL value is 3600 seconds.
             "token_header": "Authorization", // Optional. Default 'Authorization'. The name of a custom authorization header containing the token that clients submit as part of their requests.
             "validation_expression": "^Bearer \\w+$", // Optional. A validation expression for the incoming token, specify a regular expression.
+            "identity_sources": { // Optional. Default to header 'Authorization'. The name of the custom request info destined for the authorizer.
+                "header": "Authorization",
+                "query_string": "token",
+                "multi_value_query_string": "token",
+                "stage_variable": "test",
+                "context": "httpMethod",
+            }]
         },
         "keep_warm": true, // Create CloudWatch events to keep the server warm. Default true. To remove, set to false and then `unschedule`.
         "keep_warm_expression": "rate(4 minutes)", // How often to execute the keep-warm, in cron and rate format. Default 4 minutes.

--- a/README.md
+++ b/README.md
@@ -910,10 +910,10 @@ to change Zappa's behavior. Use these at your own risk!
             "token_header": "Authorization", // Optional. Default 'Authorization'. The name of a custom authorization header containing the token that clients submit as part of their requests.
             "validation_expression": "^Bearer \\w+$", // Optional. A validation expression for the incoming token, specify a regular expression.
             "identity_sources": { // Optional. The names of the custom request expressions destined for the authorizer.
-                "header": "Authorization",
-                "query_string": "token",
-                "stage_variable": "test",
-                "context": "principalId",
+                "headers": ["Authorization", "Host"],
+                "query_strings": ["token"],
+                "stage_variables": ["test"],
+                "contexts": ["principalId"],
             }
         },
         "keep_warm": true, // Create CloudWatch events to keep the server warm. Default true. To remove, set to false and then `unschedule`.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -495,7 +495,7 @@ class TestZappa(unittest.TestCase):
 
         # Authorizer and IAM
         authorizer = {
-            "type": "token",
+            "type": "TOKEN",
             "function": "runapi.authorization.gateway_authorizer.evaluate_token",
             "result_ttl": 300,
             "token_header": "Authorization",
@@ -593,16 +593,24 @@ class TestZappa(unittest.TestCase):
 
         # Authorizer of type request
         authorizer = {
-            "type": "request",
+            "type": "REQUEST",
             "function": "runapi.authorization.gateway_authorizer.evaluate_token",
             "result_ttl": 300,
-            "identity_sources": [
-                "Authorization",
-                "Host"
-            ]
+            "identity_sources": {
+                "header": "Authorization",
+                "header": "Host"
+            }
         }
         z.create_stack_template(lambda_arn, "helloworld", False, False, authorizer)
         parsable_template = json.loads(z.cf_template.to_json())
+        self.assertEqual(
+            "CUSTOM",
+            parsable_template["Resources"]["GET0"]["Properties"]["AuthorizationType"],
+        )
+        self.assertEqual(
+            "CUSTOM",
+            parsable_template["Resources"]["GET1"]["Properties"]["AuthorizationType"],
+        )
         self.assertEqual(
             "REQUEST", parsable_template["Resources"]["Authorizer"]["Properties"]["Type"]
         )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -495,6 +495,7 @@ class TestZappa(unittest.TestCase):
 
         # Authorizer and IAM
         authorizer = {
+            "type": "token",
             "function": "runapi.authorization.gateway_authorizer.evaluate_token",
             "result_ttl": 300,
             "token_header": "Authorization",
@@ -588,6 +589,22 @@ class TestZappa(unittest.TestCase):
         self.assertEqual(
             "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:my-function/invocations",
             parsable_template["Resources"]["Authorizer"]["Properties"]["AuthorizerUri"],
+        )
+
+        # Authorizer of type request
+        authorizer = {
+            "type": "request",
+            "function": "runapi.authorization.gateway_authorizer.evaluate_token",
+            "result_ttl": 300,
+            "identity_sources": [
+                "Authorization",
+                "Host"
+            ]
+        }
+        z.create_stack_template(lambda_arn, "helloworld", False, False, authorizer)
+        parsable_template = json.loads(z.cf_template.to_json())
+        self.assertEqual(
+            "REQUEST", parsable_template["Resources"]["Authorizer"]["Properties"]["Type"]
         )
 
     def test_policy_json(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -597,10 +597,10 @@ class TestZappa(unittest.TestCase):
             "function": "runapi.authorization.gateway_authorizer.evaluate_token",
             "result_ttl": 300,
             "identity_sources": {
-                "header": "Authorization",
-                "query_string": "token",
-                "stage_variable": "test",
-                "context": "principalId",
+                "headers": ["Authorization"],
+                "query_strings": ["token"],
+                "stage_variables": ["test"],
+                "contexts": ["principalId"],
             }
         }
         z.create_stack_template(lambda_arn, "helloworld", False, False, authorizer)

--- a/tests/tests_placebo.py
+++ b/tests/tests_placebo.py
@@ -443,11 +443,69 @@ class TestZappa(unittest.TestCase):
         }
         self.assertEqual("AWS SQS EVENT", lh.handler(event, None))
 
-        # Test Authorizer event
+        # Test Authorizer event of type TOKEN
         event = {
             "authorizationToken": "hubtoken1",
             "methodArn": "arn:aws:execute-api:us-west-2:1234:xxxxx/dev/GET/v1/endpoint/param",
             "type": "TOKEN",
+        }
+        self.assertEqual("AUTHORIZER_EVENT", lh.handler(event, None))
+
+        # Test Authorizer event of type REQUEST
+        event = {
+            "type": "REQUEST",
+            "methodArn": "arn:aws:execute-api:us-west-2:1234:xxxxx/dev/GET/v1/endpoint/param",
+            "resource": "/",
+            "path": "/",
+            "httpMethod": "GET",
+            "headers": {
+                "Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+                "Host": "example.com"
+            },
+            "multiValueHeaders": {
+                "Authorization": [
+                    "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+                ],
+                "Host": [
+                    "example.com"
+                ]
+            },
+            "queryStringParameters": {},
+            "multiValueQueryStringParameters": {},
+            "pathParameters": {},
+            "stageVariables": {},
+            "requestContext": {
+                "resourceId": "test-invoke-resource-id",
+                "resourcePath": "/",
+                "httpMethod": "GET",
+                "extendedRequestId": "ODtjMEaurPEFpbQ=",
+                "requestTime": "24/Feb/2022: 17: 39: 45 +0000",
+                "path": "/",
+                "accountId": "429480868624",
+                "protocol": "HTTP/1.1",
+                "stage": "test-invoke-stage",
+                "domainPrefix": "testPrefix",
+                "requestTimeEpoch": 1645724385013,
+                "requestId": "13e8a7e1-1b24-467a-afd1-854d7268db1b",
+                "identity": {
+                    "cognitoIdentityPoolId": None,
+                    "cognitoIdentityId": None,
+                    "apiKey": "test-invoke-api-key",
+                    "principalOrgId": None,
+                    "cognitoAuthenticationType": None,
+                    "userArn": "arn:aws:iam::fooo:user/my.username",
+                    "apiKeyId": "test-invoke-api-key-id",
+                    "userAgent": "aws-internal/3 aws-sdk-java/1.12.159 Linux/5.4.172-100.336.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/25.322-b06 java/1.8.0_322 vendor/Oracle_Corporation cfg/retry-mode/standard",
+                    "accountId": "429480868624",
+                    "caller": "AIDAWH7YN7MIM5EMI2SCJ",
+                    "sourceIp": "test-invoke-source-ip",
+                    "accessKey": "ASIAWH7YN7MIOMF3BO7W",
+                    "cognitoAuthenticationProvider": None,
+                    "user": None
+                },
+                "domainName": "testPrefix.testDomainName",
+                "apiId": "nyfueqhql3"
+            }
         }
         self.assertEqual("AUTHORIZER_EVENT", lh.handler(event, None))
 

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1923,14 +1923,18 @@ class Zappa:
             authorizer_resource.IdentitySource = ""
             identity_sources = authorizer.get("identity_sources", {})
             for source_key in identity_sources:
-                if source_key == "header":
-                    authorizer_resource.IdentitySource += "method.request.header.%s," % identity_sources[source_key]
-                elif source_key == "query_string":
-                    authorizer_resource.IdentitySource += "method.request.querystring.%s," % identity_sources[source_key]
-                elif source_key == "stage_variable":
-                    authorizer_resource.IdentitySource += "method.stageVariables.%s," % identity_sources[source_key]
-                elif source_key == "context":
-                    authorizer_resource.IdentitySource += "method.context.%s," % identity_sources[source_key]
+                if source_key == "headers":
+                    for header in identity_sources[source_key]:
+                        authorizer_resource.IdentitySource += "method.request.header.%s," % header
+                elif source_key == "query_strings":
+                    for query_string in identity_sources[source_key]:
+                        authorizer_resource.IdentitySource += "method.request.querystring.%s," % query_string
+                elif source_key == "stage_variables":
+                    for stage_variable in identity_sources[source_key]:
+                        authorizer_resource.IdentitySource += "method.stageVariables.%s," % stage_variable
+                elif source_key == "contexts":
+                    for context in identity_sources[source_key]:
+                        authorizer_resource.IdentitySource += "method.context.%s," % context
 
             if len(authorizer_resource.IdentitySource) > 1 and authorizer_resource.IdentitySource[-1] == ',':
                 authorizer_resource.IdentitySource = authorizer_resource.IdentitySource[:-1]

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1921,7 +1921,7 @@ class Zappa:
                 "result_ttl", 300
             )
             authorizer_resource.IdentitySource = ""
-            identity_sources = authorizer.get("identity_sources", {'header': 'Authorization'})
+            identity_sources = authorizer.get("identity_sources", {})
             for source_key in identity_sources:
                 if source_key == "header":
                     authorizer_resource.IdentitySource += "method.request.header.%s," % identity_sources[source_key]
@@ -1932,7 +1932,7 @@ class Zappa:
                 elif source_key == "context":
                     authorizer_resource.IdentitySource += "method.context.%s," % identity_sources[source_key]
 
-            if authorizer_resource.IdentitySource[-1] == ',':
+            if len(authorizer_resource.IdentitySource) > 1 and authorizer_resource.IdentitySource[-1] == ',':
                 authorizer_resource.IdentitySource = authorizer_resource.IdentitySource[:-1]
 
         self.cf_api_resources.append(authorizer_resource.title)

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1896,9 +1896,16 @@ class Zappa:
         authorizer_resource.Name = authorizer.get("name", "ZappaAuthorizer")
         authorizer_resource.Type = authorizer_type
         authorizer_resource.AuthorizerUri = uri
-        authorizer_resource.IdentitySource = (
+        authorizer_resource.TokenSource = (
             "method.request.header.%s" % authorizer.get("token_header", "Authorization")
         )
+        authorizer_resource.IdentitySources = [(
+            "method.request.header.%s" % authorizer.get("identity_source", "Authorization")
+        ),
+        (
+            "method.request.header.%s" % authorizer.get("identity_source", "Host")
+        )
+        ]
         if identity_validation_expression:
             authorizer_resource.IdentityValidationExpression = (
                 identity_validation_expression
@@ -1913,6 +1920,12 @@ class Zappa:
             authorizer_resource.AuthorizerCredentials = self.credentials_arn
         if authorizer_type == "COGNITO_USER_POOLS":
             authorizer_resource.ProviderARNs = authorizer.get("provider_arns")
+        if authorizer_type == "REQUEST":
+            if not self.credentials_arn:
+                self.get_credentials_arn()
+            authorizer_resource.AuthorizerResultTtlInSeconds = authorizer.get(
+                "result_ttl", 300
+            )
 
         self.cf_api_resources.append(authorizer_resource.title)
         self.cf_template.add_resource(authorizer_resource)

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1896,16 +1896,7 @@ class Zappa:
         authorizer_resource.Name = authorizer.get("name", "ZappaAuthorizer")
         authorizer_resource.Type = authorizer_type
         authorizer_resource.AuthorizerUri = uri
-        authorizer_resource.TokenSource = (
-            "method.request.header.%s" % authorizer.get("token_header", "Authorization")
-        )
-        authorizer_resource.IdentitySources = [(
-            "method.request.header.%s" % authorizer.get("identity_source", "Authorization")
-        ),
-        (
-            "method.request.header.%s" % authorizer.get("identity_source", "Host")
-        )
-        ]
+
         if identity_validation_expression:
             authorizer_resource.IdentityValidationExpression = (
                 identity_validation_expression
@@ -1917,6 +1908,9 @@ class Zappa:
             authorizer_resource.AuthorizerResultTtlInSeconds = authorizer.get(
                 "result_ttl", 300
             )
+            authorizer_resource.IdentitySource = (
+                "method.request.header.%s" % authorizer.get("token_header", "Authorization")
+            )
             authorizer_resource.AuthorizerCredentials = self.credentials_arn
         if authorizer_type == "COGNITO_USER_POOLS":
             authorizer_resource.ProviderARNs = authorizer.get("provider_arns")
@@ -1925,6 +1919,9 @@ class Zappa:
                 self.get_credentials_arn()
             authorizer_resource.AuthorizerResultTtlInSeconds = authorizer.get(
                 "result_ttl", 300
+            )
+            authorizer_resource.IdentitySource = (
+                "method.request.header.%s" % authorizer.get("identity_sources", {"header": "Authorization"})
             )
 
         self.cf_api_resources.append(authorizer_resource.title)

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1920,6 +1920,7 @@ class Zappa:
             authorizer_resource.AuthorizerResultTtlInSeconds = authorizer.get(
                 "result_ttl", 300
             )
+            authorizer_resource.IdentitySource = ""
             identity_sources = authorizer.get("identity_sources", {'header': 'Authorization'})
             for source_key in identity_sources:
                 if source_key == "header":

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -457,7 +457,7 @@ class LambdaHandler:
             return result
 
         # This is an API Gateway authorizer event
-        elif event.get("type") == "TOKEN":
+        elif event.get("type") in ["TOKEN", "REQUEST"]:
             whole_function = self.settings.AUTHORIZER_FUNCTION
             if whole_function:
                 app_function = self.import_module_and_get_function(whole_function)


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/zappa/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.6**, **Python 3.7** and **Python 3.8** ? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
AWS gateway supports the use of Lambda authorizers to perform authorization (grant access to certain resources) based on a given authentication strategy (OpenID connect, basic auth, SAML etc). AWS Gateway offers two kinds of authorizers: REQUEST & TOKEN. 

TOKEN authorizers receive the bearer token, like a JWT or a OAuth token.

REQUEST authorizers receive a combination of headers, query strings, stage variables and context variables.

Zappa only supports TOKEN authorizers, which is quite limiting since some authentication schemes may depend on information provided in the request.

This PR adds support for REQUEST authorizers. The authorizer config now takes a new `type` field as well as an `identity_sources` object which can be a combination of the various request expressions needed for the `REQUEST` authorizer (header, query string, stage variable, or context). We don't explicity support multi stage variable since fields can appear multiple times e.g.
```
"authorizer": {
  "type": "REQUEST",
  "function": "auth.lambda_handler",
  "identity_sources": {
    "headers": ["Authorization", "Host"],
    "stage_variables": ["prod", "dev"]
  },
}
```

For backwards compatibility, if the `type` of an authorizer is not specified, it defaults to `TOKEN`.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

https://github.com/zappa/Zappa/issues/847
https://github.com/Miserlou/Zappa/issues/1159