### PR TITLE
Add Support for Graviton 2 / ARM Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,6 +833,7 @@ to change Zappa's behavior. Use these at your own risk!
         "assume_policy": "my_assume_policy.json", // optional, IAM assume policy JSON file
         "attach_policy": "my_attach_policy.json", // optional, IAM attach policy JSON file
         "apigateway_policy": "my_apigateway_policy.json", // optional, API Gateway resource policy JSON file
+        "architectures": "x86_64", // optional, Set Lambda Architecture, defaults to x86_64. For Graviton 2 use: arm64
         "async_source": "sns", // Source of async tasks. Defaults to "lambda"
         "async_resources": true, // Create the SNS topic and DynamoDB table to use. Defaults to true.
         "async_response_table": "your_dynamodb_table_name",  // the DynamoDB table name to use for captured async responses; defaults to None (can't capture)

--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ to change Zappa's behavior. Use these at your own risk!
         "assume_policy": "my_assume_policy.json", // optional, IAM assume policy JSON file
         "attach_policy": "my_attach_policy.json", // optional, IAM attach policy JSON file
         "apigateway_policy": "my_apigateway_policy.json", // optional, API Gateway resource policy JSON file
-        "architectures": "x86_64", // optional, Set Lambda Architecture, defaults to x86_64. For Graviton 2 use: arm64
+        "architecture": "x86_64", // optional, Set Lambda Architecture, defaults to x86_64. For Graviton 2 use: arm64
         "async_source": "sns", // Source of async tasks. Defaults to "lambda"
         "async_resources": true, // Create the SNS topic and DynamoDB table to use. Defaults to true.
         "async_response_table": "your_dynamodb_table_name",  // the DynamoDB table name to use for captured async responses; defaults to None (can't capture)

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -126,6 +126,7 @@ class ZappaCLI:
     context_header_mappings = None
     tags = []
     layers = None
+    architecture = None
 
     stage_name_env_pattern = re.compile("^[a-zA-Z0-9_]+$")
 
@@ -911,6 +912,7 @@ class ZappaCLI:
                 use_alb=self.use_alb,
                 layers=self.layers,
                 concurrency=self.lambda_concurrency,
+                architecture=self.architecture,
             )
             kwargs["function_name"] = self.lambda_name
             if docker_image_uri:
@@ -1136,6 +1138,7 @@ class ZappaCLI:
             function_name=self.lambda_name,
             num_revisions=self.num_retained_versions,
             concurrency=self.lambda_concurrency,
+            architecture=self.architecture,
         )
         if docker_image_uri:
             kwargs["docker_image_uri"] = docker_image_uri
@@ -1172,6 +1175,8 @@ class ZappaCLI:
             aws_kms_key_arn=self.aws_kms_key_arn,
             layers=self.layers,
             wait=False,
+            architecture=self.architecture,
+
         )
 
         # Finally, delete the local copy our zip package
@@ -2544,7 +2549,7 @@ class ZappaCLI:
         self.num_retained_versions = self.stage_config.get(
             "num_retained_versions", None
         )
-
+        self.architecture = [self.stage_config.get("architecture", "x86_64")]
         # Check for valid values of num_retained_versions
         if (
             self.num_retained_versions is not None
@@ -2615,6 +2620,9 @@ class ZappaCLI:
         # Additional tags
         self.tags = self.stage_config.get("tags", {})
 
+        # Architectures
+        self.architecture = [self.stage_config.get("architecture", "x86_64")]
+
         desired_role_name = self.lambda_name + "-ZappaLambdaExecutionRole"
         self.zappa = Zappa(
             boto_session=session,
@@ -2627,6 +2635,7 @@ class ZappaCLI:
             tags=self.tags,
             endpoint_urls=self.stage_config.get("aws_endpoint_urls", {}),
             xray_tracing=self.xray_tracing,
+            architecture=self.architecture
         )
 
         for setting in CUSTOM_SETTINGS:


### PR DESCRIPTION
## Description
This PR adds support for the 'new' Graviton 2 / ARM64 architecture. It builds on top of @[turingbeing](https://github.com/turingbeing)'s work (https://github.com/zappa/Zappa/pull/1057)

The new parameter is now a string instead of a list, defaulting to 'x86_64' if not defined.

Keep in mind that ARM64 is not supported in all regions. It is currently unsupported in the following regions: af-south-1, ap-east-1, ap-northeast-2, ap-northeast-3, ca-central-1, eu-south-1, eu-west-3, eu-north-1, me-south-1, sa-east-1 and us-west-1

It seems like AWS will fall back to x86 if the region does not support ARM.

@[hellno](https://github.com/hellno) can you review the PR?

AWS API [Docs](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#API_CreateFunction_RequestSyntax)

## GitHub Issues
Resolves: #1051

