### PR TITLE
Add python3.9 to documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--- Provide a general summary of the issue in the Title above -->
 ## Context
 <!--- Provide a more detailed introduction to the issue itself, and why you consider it to be a bug -->
-<!--- Also, please make sure that you are running Zappa _from a virtual environment_ and are using Python 3.6/3.7/3.8 -->
+<!--- Also, please make sure that you are running Zappa _from a virtual environment_ and are using Python 3.6/3.7/3.8/3.9 -->
 
 ## Expected Behavior
 <!--- Tell us what should happen -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ Before you submit this PR, please make sure that you meet these criteria:
 
 * Did you **make sure this code actually works on Lambda**, as well as locally?
 
-* Did you test this code with all of **Python 3.6**, **Python 3.7** and **Python 3.8** ? 
+* Did you test this code with all of **Python 3.6**, **Python 3.7**, **Python 3.8** and **Python 3.9 ? 
 
 * Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Zappa Changelog
 
 ## 0.54.2
-* Update documentation to reflect python 3.9 support
+* Update documentation to reflect python 3.9 support (#1137)
 
 ## 0.54.1
 * Increase Lambda client read timeout to 15m (#1065)
@@ -11,6 +11,7 @@
 * Pin troposphere version and update to 3.x (#1029)
 * Relax stage name restrictions when not using apigateway (#993)
 * Wait for lambda to become active during deploy/update (#992)
+* add support for Python 3.9 (#1026)
 
 ## 0.53.0
 * Deprecated ACME v1 for Lets Encrypt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Zappa Changelog
 
+## 0.54.2
+* Update documentation to reflect python 3.9 support
+
 ## 0.54.1
 * Increase Lambda client read timeout to 15m (#1065)
 * Unpin `Werkzeug` from `v0.x` (#1067)
@@ -8,7 +11,6 @@
 * Pin troposphere version and update to 3.x (#1029)
 * Relax stage name restrictions when not using apigateway (#993)
 * Wait for lambda to become active during deploy/update (#992)
-* add support for Python 3.9 (#1026)
 
 ## 0.53.0
 * Deprecated ACME v1 for Lets Encrypt

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ __Awesome!__
 
 ## Installation and Configuration
 
-_Before you begin, make sure you are running Python 3.6/3.7/3.8 and you have a valid AWS account and your [AWS credentials file](https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs) is properly installed._
+_Before you begin, make sure you are running Python 3.6/3.7/3.8/3.9 and you have a valid AWS account and your [AWS credentials file](https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs) is properly installed._
 
 **Zappa** can easily be installed through pip, like so:
 
@@ -397,7 +397,7 @@ For instance, suppose you have a basic application in a file called "my_app.py",
 
 Any remote print statements made and the value the function returned will then be printed to your local console. **Nifty!**
 
-You can also invoke interpretable Python 3.6/3.7/3.8 strings directly by using `--raw`, like so:
+You can also invoke interpretable Python 3.6/3.7/3.8/3.9 strings directly by using `--raw`, like so:
 
     $ zappa invoke production "print(1 + 2 + 3)" --raw
 
@@ -928,7 +928,7 @@ to change Zappa's behavior. Use these at your own risk!
         "role_name": "MyLambdaRole", // Name of Zappa execution role. Default <project_name>-<env>-ZappaExecutionRole. To use a different, pre-existing policy, you must also set manage_roles to false.
         "role_arn": "arn:aws:iam::12345:role/app-ZappaLambdaExecutionRole", // ARN of Zappa execution role. Default to None. To use a different, pre-existing policy, you must also set manage_roles to false. This overrides role_name. Use with temporary credentials via GetFederationToken.
         "route53_enabled": true, // Have Zappa update your Route53 Hosted Zones when certifying with a custom domain. Default true.
-        "runtime": "python3.6", // Python runtime to use on Lambda. Can be one of "python3.6", "python3.7" or "python3.8". Defaults to whatever the current Python being used is.
+        "runtime": "python3.6", // Python runtime to use on Lambda. Can be one of "python3.6", "python3.7", "python3.8", or "python3.9". Defaults to whatever the current Python being used is.
         "s3_bucket": "dev-bucket", // Zappa zip bucket,
         "slim_handler": false, // Useful if project >50M. Set true to just upload a small handler to Lambda and load actual project from S3 at runtime. Default false.
         "settings_file": "~/Projects/MyApp/settings/dev_settings.py", // Server side settings file location,


### PR DESCRIPTION

## Description

:pencil: Add python3.9 to documentation (python 3.9 already supported in 0.54.1)

## GitHub Issues

https://github.com/zappa/Zappa/issues/1137
