### PR TITLE
Remove special check for Django<1.7, fix for #1158 

### DIFF
--- a/zappa/ext/django_zappa.py
+++ b/zappa/ext/django_zappa.py
@@ -10,12 +10,4 @@ def get_django_wsgi(settings_module):
 
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings_module)
 
-    import django
-
-    if django.VERSION[0] <= 1 and django.VERSION[1] < 7:
-        # call django.setup only for django <1.7.0
-        # (because setup already in get_wsgi_application since that)
-        # https://github.com/django/django/commit/80d74097b4bd7186ad99b6d41d0ed90347a39b21
-        django.setup()
-
     return get_wsgi_application()


### PR DESCRIPTION
## Description
Removing a long-obsolete check for Django versions less than 1.7 which made a setup() call that is no longer required.

## GitHub Issues
https://github.com/zappa/Zappa/issues/1158
