### PR TITLE
Handle spaces in x-forwared-for/remove six (#1127)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -35,7 +35,6 @@ python-slugify = "*"
 PyYAML = "*"
 # previous versions don't work with urllib3 1.24
 requests = ">=2.20.0"
-six = "*"
 toml = "*"
 tqdm = "*"
 troposphere = ">=3.0"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -763,7 +763,7 @@ class TestZappa(unittest.TestCase):
 
         request = create_wsgi_request(event)
 
-    def test_wsgi_event__handle_space_in_xforwardedfor(self):
+    def test_wsgi_event_handle_space_in_xforwardedfor(self):
         event = {
             "body": None,
             "resource": "/",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2725,7 +2725,6 @@ USE_TZ = True
 
     @mock.patch("sys.version_info", new_callable=get_unsupported_sys_versioninfo)
     def test_unsupported_version_error(self, m):
-        import sys
         from importlib import reload
 
         with self.assertRaises(RuntimeError):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -740,37 +740,6 @@ class TestZappa(unittest.TestCase):
         request = create_wsgi_request(event)
 
     def test_wsgi_event__handle_space_in_xforwardedfor(self):
-
-        ## This is a pre-proxy+ event
-        # event = {
-        #     "body": "",
-        #     "headers": {
-        #         "Via": "1.1 e604e934e9195aaf3e36195adbcb3e18.cloudfront.net (CloudFront)",
-        #         "Accept-Language": "en-US,en;q=0.5",
-        #         "Accept-Encoding": "gzip",
-        #         "CloudFront-Is-SmartTV-Viewer": "false",
-        #         "CloudFront-Forwarded-Proto": "https",
-        #         "X-Forwarded-For": "109.81.209.118, 216.137.58.43",
-        #         "CloudFront-Viewer-Country": "CZ",
-        #         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        #         "X-Forwarded-Proto": "https",
-        #         "X-Amz-Cf-Id": "LZeP_TZxBgkDt56slNUr_H9CHu1Us5cqhmRSswOh1_3dEGpks5uW-g==",
-        #         "CloudFront-Is-Tablet-Viewer": "false",
-        #         "X-Forwarded-Port": "443",
-        #         "CloudFront-Is-Mobile-Viewer": "false",
-        #         "CloudFront-Is-Desktop-Viewer": "true",
-        #         "Content-Type": "application/json"
-        #     },
-        #     "params": {
-        #         "parameter_1": "asdf1",
-        #         "parameter_2": "asdf2",
-        #     },
-        #     "method": "POST",
-        #     "query": {
-        #         "dead": "beef"
-        #     }
-        # }
-
         event = {
             "body": None,
             "resource": "/",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2724,7 +2724,7 @@ USE_TZ = True
         )
 
     @mock.patch("sys.version_info", new_callable=get_unsupported_sys_versioninfo)
-    def test_unsupported_version_error(self, m):
+    def test_unsupported_version_error(self, *_):
         from importlib import reload
 
         with self.assertRaises(RuntimeError):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -739,6 +739,93 @@ class TestZappa(unittest.TestCase):
 
         request = create_wsgi_request(event)
 
+    def test_wsgi_event__handle_space_in_xforwardedfor(self):
+
+        ## This is a pre-proxy+ event
+        # event = {
+        #     "body": "",
+        #     "headers": {
+        #         "Via": "1.1 e604e934e9195aaf3e36195adbcb3e18.cloudfront.net (CloudFront)",
+        #         "Accept-Language": "en-US,en;q=0.5",
+        #         "Accept-Encoding": "gzip",
+        #         "CloudFront-Is-SmartTV-Viewer": "false",
+        #         "CloudFront-Forwarded-Proto": "https",
+        #         "X-Forwarded-For": "109.81.209.118, 216.137.58.43",
+        #         "CloudFront-Viewer-Country": "CZ",
+        #         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        #         "X-Forwarded-Proto": "https",
+        #         "X-Amz-Cf-Id": "LZeP_TZxBgkDt56slNUr_H9CHu1Us5cqhmRSswOh1_3dEGpks5uW-g==",
+        #         "CloudFront-Is-Tablet-Viewer": "false",
+        #         "X-Forwarded-Port": "443",
+        #         "CloudFront-Is-Mobile-Viewer": "false",
+        #         "CloudFront-Is-Desktop-Viewer": "true",
+        #         "Content-Type": "application/json"
+        #     },
+        #     "params": {
+        #         "parameter_1": "asdf1",
+        #         "parameter_2": "asdf2",
+        #     },
+        #     "method": "POST",
+        #     "query": {
+        #         "dead": "beef"
+        #     }
+        # }
+
+        event = {
+            "body": None,
+            "resource": "/",
+            "requestContext": {
+                "resourceId": "6cqjw9qu0b",
+                "apiId": "9itr2lba55",
+                "resourcePath": "/",
+                "httpMethod": "GET",
+                "requestId": "c17cb1bf-867c-11e6-b938-ed697406e3b5",
+                "accountId": "724336686645",
+                "identity": {
+                    "apiKey": None,
+                    "userArn": None,
+                    "cognitoAuthenticationType": None,
+                    "caller": None,
+                    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:48.0) Gecko/20100101 Firefox/48.0",
+                    "user": None,
+                    "cognitoIdentityPoolId": None,
+                    "cognitoIdentityId": None,
+                    "cognitoAuthenticationProvider": None,
+                    "sourceIp": "50.191.225.98",
+                    "accountId": None,
+                },
+                "stage": "devorr",
+            },
+            "queryStringParameters": None,
+            "httpMethod": "GET",
+            "pathParameters": None,
+            "headers": {
+                "Via": "1.1 6801928d54163af944bf854db8d5520e.cloudfront.net (CloudFront)",
+                "Accept-Language": "en-US,en;q=0.5",
+                "Accept-Encoding": "gzip, deflate, br",
+                "CloudFront-Is-SmartTV-Viewer": "false",
+                "CloudFront-Forwarded-Proto": "https",
+                "X-Forwarded-For": "50.191.225.98 , 204.246.168.101",
+                "CloudFront-Viewer-Country": "US",
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                "Upgrade-Insecure-Requests": "1",
+                "Host": "9itr2lba55.execute-api.us-east-1.amazonaws.com",
+                "X-Forwarded-Proto": "https",
+                "X-Amz-Cf-Id": "qgNdqKT0_3RMttu5KjUdnvHI3OKm1BWF8mGD2lX8_rVrJQhhp-MLDw==",
+                "CloudFront-Is-Tablet-Viewer": "false",
+                "X-Forwarded-Port": "443",
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:48.0) Gecko/20100101 Firefox/48.0",
+                "CloudFront-Is-Mobile-Viewer": "false",
+                "CloudFront-Is-Desktop-Viewer": "true",
+            },
+            "stageVariables": None,
+            "path": "/",
+        }
+        expected = "50.191.225.98"
+        request = create_wsgi_request(event)
+        actual = request["REMOTE_ADDR"]
+        self.assertEqual(actual, expected)
+
     def test_wsgi_path_info_unquoted(self):
         event = {
             "body": {},

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -57,7 +57,7 @@ from zappa.utilities import (
 )
 from zappa.wsgi import common_log, create_wsgi_request
 
-from .utils import get_invalid_sys_versioninfo
+from .utils import get_unsupported_sys_versioninfo
 
 
 def random_string(length):
@@ -2723,7 +2723,7 @@ USE_TZ = True
             FunctionName="abc",
         )
 
-    @mock.patch("sys.version_info", new_callable=get_invalid_sys_versioninfo)
+    @mock.patch("sys.version_info", new_callable=get_unsupported_sys_versioninfo)
     def test_unsupported_version_error(self, m):
         import sys
         from importlib import reload

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -57,6 +57,8 @@ from zappa.utilities import (
 )
 from zappa.wsgi import common_log, create_wsgi_request
 
+from .utils import get_invalid_sys_versioninfo
+
 
 def random_string(length):
     return "".join(random.choice(string.printable) for _ in range(length))
@@ -2720,6 +2722,14 @@ USE_TZ = True
         boto_mock.client().delete_function_concurrency.assert_called_with(
             FunctionName="abc",
         )
+
+    @mock.patch("sys.version_info", new_callable=get_invalid_sys_versioninfo)
+    def test_unsupported_version_error(self, m):
+        import sys
+        from importlib import reload
+        with self.assertRaises(RuntimeError):
+            import zappa
+            reload(zappa)
 
 
 if __name__ == "__main__":

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2732,6 +2732,19 @@ USE_TZ = True
 
             reload(zappa)
 
+    def test_wsgi_query_string_unquoted(self):
+        event = {
+            "body": {},
+            "headers": {},
+            "pathParameters": {},
+            "path": "/path/path1",
+            "httpMethod": "GET",
+            "queryStringParameters": {"a": "A,B", "b": "C#D"},
+            "requestContext": {},
+        }
+        request = create_wsgi_request(event)
+        self.assertEqual(request["QUERY_STRING"], "a=A,B&b=C#D")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2727,8 +2727,10 @@ USE_TZ = True
     def test_unsupported_version_error(self, m):
         import sys
         from importlib import reload
+
         with self.assertRaises(RuntimeError):
             import zappa
+
             reload(zappa)
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1009,6 +1009,89 @@ class TestZappa(unittest.TestCase):
         response_tuple = collections.namedtuple("Response", ["status_code", "content"])
         response = response_tuple(200, "hello")
 
+    def test_wsgi_without_requestcontext(self):
+        event = {
+            "body": None,
+            "resource": "/",
+            "queryStringParameters": None,
+            "pathParameters": None,
+            "headers": {
+                "Via": "1.1 38205a04d96d60185e88658d3185ccee.cloudfront.net (CloudFront)",
+                "Accept-Language": "en-US,en;q=0.5",
+                "Accept-Encoding": "gzip, deflate, br",
+                "CloudFront-Is-SmartTV-Viewer": "false",
+                "CloudFront-Forwarded-Proto": "https",
+                "X-Forwarded-For": "71.231.27.57, 104.246.180.51",
+                "CloudFront-Viewer-Country": "US",
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:45.0) Gecko/20100101 Firefox/45.0",
+                "Host": "xo2z7zafjh.execute-api.us-east-1.amazonaws.com",
+                "X-Forwarded-Proto": "https",
+                "Cookie": "zappa=AQ4",
+                "CloudFront-Is-Tablet-Viewer": "false",
+                "X-Forwarded-Port": "443",
+                "Referer": "https://xo8z7zafjh.execute-api.us-east-1.amazonaws.com/former/post",
+                "CloudFront-Is-Mobile-Viewer": "false",
+                "X-Amz-Cf-Id": "31zxcUcVyUxBOMk320yh5NOhihn5knqrlYQYpGGyOngKKwJb0J0BAQ==",
+                "CloudFront-Is-Desktop-Viewer": "true",
+            },
+            "stageVariables": None,
+            "path": "/",
+            "isBase64Encoded": True,
+        }
+        environ = create_wsgi_request(event, trailing_slash=False)
+        self.assertTrue(environ)
+
+    def test_wsgi_with_authorizer(self):
+        expected_remote_user = "remote-user"
+        authorizer = {
+            "principalId": expected_remote_user,
+        }
+        event = {
+            "body": None,
+            "resource": "/",
+            "requestContext": {
+                "resourceId": "6cqjw9qu0b",
+                "apiId": "9itr2lba55",
+                "resourcePath": "/",
+                "httpMethod": "POST",
+                "requestId": "c17cb1bf-867c-11e6-b938-ed697406e3b5",
+                "accountId": "724336686645",
+                "authorizer": authorizer,
+                "stage": "devorr",
+            },
+            "queryStringParameters": None,
+            "httpMethod": "POST",
+            "pathParameters": None,
+            "headers": {
+                "Via": "1.1 38205a04d96d60185e88658d3185ccee.cloudfront.net (CloudFront)",
+                "Accept-Language": "en-US,en;q=0.5",
+                "Accept-Encoding": "gzip, deflate, br",
+                "CloudFront-Is-SmartTV-Viewer": "false",
+                "CloudFront-Forwarded-Proto": "https",
+                "X-Forwarded-For": "71.231.27.57, 104.246.180.51",
+                "CloudFront-Viewer-Country": "US",
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:45.0) Gecko/20100101 Firefox/45.0",
+                "Host": "xo2z7zafjh.execute-api.us-east-1.amazonaws.com",
+                "X-Forwarded-Proto": "https",
+                "Cookie": "zappa=AQ4",
+                "CloudFront-Is-Tablet-Viewer": "false",
+                "X-Forwarded-Port": "443",
+                "Referer": "https://xo8z7zafjh.execute-api.us-east-1.amazonaws.com/former/post",
+                "CloudFront-Is-Mobile-Viewer": "false",
+                "X-Amz-Cf-Id": "31zxcUcVyUxBOMk320yh5NOhihn5knqrlYQYpGGyOngKKwJb0J0BAQ==",
+                "CloudFront-Is-Desktop-Viewer": "true",
+            },
+            "stageVariables": None,
+            "path": "/",
+            "isBase64Encoded": True,
+        }
+
+        environ = create_wsgi_request(event, trailing_slash=False)
+        self.assertEqual(environ["REMOTE_USER"], expected_remote_user)
+        self.assertDictEqual(environ["API_GATEWAY_AUTHORIZER"], authorizer)
+
     def test_wsgi_from_apigateway_testbutton(self):
         """
         API Gateway resources have a "test bolt" button on methods.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,7 @@
 import functools
 import os
-from contextlib import contextmanager
 from collections import namedtuple
+from contextlib import contextmanager
 
 import boto3
 import placebo

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 import functools
 import os
 from contextlib import contextmanager
+from collections import namedtuple
 
 import boto3
 import placebo
@@ -72,3 +73,8 @@ def patch_open():
 
     with patch("__builtin__.open", stub_open):
         yield mock_open, mock_file
+
+
+def get_invalid_sys_versioninfo() -> tuple:
+    invalid_versioninfo = namedtuple("version_info", ["major", "minor", "micro", "releaselevel", "serial"])
+    return invalid_versioninfo(3, 6, 1, "final", 0)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -75,6 +75,6 @@ def patch_open():
         yield mock_open, mock_file
 
 
-def get_invalid_sys_versioninfo() -> tuple:
+def get_unsupported_sys_versioninfo() -> tuple:
     invalid_versioninfo = namedtuple("version_info", ["major", "minor", "micro", "releaselevel", "serial"])
     return invalid_versioninfo(3, 6, 1, "final", 0)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -76,5 +76,6 @@ def patch_open():
 
 
 def get_unsupported_sys_versioninfo() -> tuple:
+    """Mock used to test the python unsupported version testcase"""
     invalid_versioninfo = namedtuple("version_info", ["major", "minor", "micro", "releaselevel", "serial"])
     return invalid_versioninfo(3, 6, 1, "final", 0)

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -45,6 +45,7 @@ def create_wsgi_request(
     else:
         query = event_info.get("queryStringParameters", {})
         query_string = urlencode(query) if query else ""
+    query_string = urls.url_unquote(query_string)
 
     if context_header_mappings:
         for key, value in context_header_mappings.items():

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -94,7 +94,7 @@ def create_wsgi_request(
         # The last one is the cloudfront proxy ip. The second to last is the real client ip.
         # Everything else is user supplied and untrustworthy.
         addresses = [addr.strip() for addr in x_forwarded_for.split(",")]
-        remote_addr = addresses[-2]  # get client ip
+        remote_addr = addresses[-2]
     else:
         remote_addr = x_forwarded_for or "127.0.0.1"
 

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -100,7 +100,8 @@ def create_wsgi_request(
     if "," in x_forwarded_for:
         # The last one is the cloudfront proxy ip. The second to last is the real client ip.
         # Everything else is user supplied and untrustworthy.
-        remote_addr = x_forwarded_for.split(", ")[-2]
+        addresses = [addr.strip() for addr in x_forwarded_for.split(",")]
+        remote_addr = addresses[-2]  # get client ip
     else:
         remote_addr = x_forwarded_for or "127.0.0.1"
 

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -1,9 +1,9 @@
 import base64
 import logging
 import sys
+from io import BytesIO
 from urllib.parse import urlencode
 
-import six
 from requestlogger import ApacheFormatter
 from werkzeug import urls
 
@@ -77,12 +77,12 @@ def create_wsgi_request(
             body = base64.b64decode(encoded_body)
         else:
             body = event_info["body"]
-            if isinstance(body, six.string_types):
+            if isinstance(body, str):
                 body = body.encode("utf-8")
 
     else:
         body = event_info["body"]
-        if isinstance(body, six.string_types):
+        if isinstance(body, str):
             body = body.encode("utf-8")
 
     # Make header names canonical, e.g. content-type => Content-Type
@@ -129,7 +129,7 @@ def create_wsgi_request(
             environ["CONTENT_TYPE"] = headers["Content-Type"]
 
         # This must be Bytes or None
-        environ["wsgi.input"] = six.BytesIO(body)
+        environ["wsgi.input"] = BytesIO(body)
         if body:
             environ["CONTENT_LENGTH"] = str(len(body))
         else:


### PR DESCRIPTION
- Whitespace in X-Forwarded-For is optional and therefore should handle the case when there is no whitespace (contribution by [naresh-uplight](https://github.com/naresh-uplight))
- :fire: remove six from zappa dependencies
- :wrench: Fix url decoding for query string (contribution by [choich](https://github.com/zappa/Zappa/pull/952))

> `six` is still a sub-dependency of boto3, but no longer required directly by zappa.

Related Issue(s):
https://github.com/zappa/Zappa/issues/879
https://github.com/zappa/Zappa/issues/1127
https://github.com/zappa/Zappa/issues/1164

Related PR:
https://github.com/zappa/Zappa/pull/972  (integrated into this PR)  contribution by ([pauldes](https://github.com/pauldes))