### PR TITLE
docs: Add documentation for s3 event object key_filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,15 @@ In your *zappa_settings.json* file, define your [event sources](http://docs.aws.
                   "arn":  "arn:aws:s3:::my-bucket",
                   "events": [
                     "s3:ObjectCreated:*" // Supported event types: http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#supported-notification-event-types
-                  ]
+                  ],
+                  "key_filters": [{ // optional
+                    "type": "suffix",
+                    "value": "yourfile.json"
+                  },
+                  {
+                    "type": "prefix",
+                    "value": "prefix/for/your/object"
+                  }]
                }
             }],
        ...


### PR DESCRIPTION
## Description

People are having trouble with how to add event key_filters for s3 events. I gave an answer to them on SO.

https://stackoverflow.com/questions/69455698/how-to-add-a-suffix-to-an-event-in-lambda-function-with-zappa/73493272#73493272

I just verified this behavior works for our organization as well.

There was also an open issue for this, but it never went anywhere because of a typo.

## GitHub Issues

https://github.com/zappa/Zappa/issues/446
