### PR TITLE
Improve `get_best_match_zone()` to match by most matched components instead of by length of domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,7 +928,7 @@ to change Zappa's behavior. Use these at your own risk!
         ],
         "endpoint_configuration": ["EDGE", "REGIONAL", "PRIVATE"],  // Specify APIGateway endpoint None (default) or list `EDGE`, `REGION`, `PRIVATE`
         "exception_handler": "your_module.report_exception", // function that will be invoked in case Zappa sees an unhandled exception raised from your code
-        "exclude": ["file.gz", "tests/"], // A list of regex patterns to exclude from the archive.
+        "exclude": ["file.gz", "tests"], // A list of filename patterns to exclude from the archive (see `fnmatch` module for patterns).
         "exclude_glob": ["*.gz", "*.rar", "tests/**/*"], // A list of glob patterns to exclude from the archive. To exclude boto3 and botocore (available in an older version on Lambda), add "boto3*" and "botocore*".
         "extends": "stage_name", // Duplicate and extend another stage's settings. For example, `dev-asia` could extend from `dev-common` with a different `s3_bucket` value.
         "extra_permissions": [{ // Attach any extra permissions to this policy. Default None

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1689,6 +1689,26 @@ class TestZappa(unittest.TestCase):
         )
         assert zone == "zone-correct"
 
+    def test_domain_name_match_components_short(self):
+        zone = Zappa.get_best_match_zone(
+            all_zones={
+                "HostedZones": [
+                    {
+                        "Name": "beta.example.com.",
+                        "Id": "zone-incorrect",
+                        "Config": {"PrivateZone": False},
+                    },
+                    {
+                        "Name": "example.com.",
+                        "Id": "zone-correct",
+                        "Config": {"PrivateZone": False},
+                    },
+                ]
+            },
+            domain="example.com",
+        )
+        assert zone == "zone-correct"
+
     ##
     # Let's Encrypt / ACME
     ##

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1674,12 +1674,12 @@ class TestZappa(unittest.TestCase):
             all_zones={
                 "HostedZones": [
                     {
-                        "Name": "example.com",
+                        "Name": "example.com.",
                         "Id": "zone-correct",
                         "Config": {"PrivateZone": False},
                     },
                     {
-                        "Name": "beta.example.com",
+                        "Name": "beta.example.com.",
                         "Id": "zone-incorrect",
                         "Config": {"PrivateZone": False},
                     },

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1668,6 +1668,27 @@ class TestZappa(unittest.TestCase):
         )
         assert zone == "zone-public"
 
+    def test_domain_name_match_components(self):
+        # Simple sanity check
+        zone = Zappa.get_best_match_zone(
+            all_zones={
+                "HostedZones": [
+                    {
+                        "Name": "example.com",
+                        "Id": "zone-correct",
+                        "Config": {"PrivateZone": False},
+                    },
+                    {
+                        "Name": "beta.example.com",
+                        "Id": "zone-incorrect",
+                        "Config": {"PrivateZone": False},
+                    },
+                ]
+            },
+            domain="some-beta.example.com",
+        )
+        assert zone == "zone-correct"
+
     ##
     # Let's Encrypt / ACME
     ##

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -3202,9 +3202,10 @@ class Zappa:
         candidate_zones = {}
         for zone in all_zones["HostedZones"]:
             if not zone["Config"]["PrivateZone"]:
-                public_zone_name = zone["Name"][:-1]
+                public_zone_name = zone["Name"][:-1]  # zone "Name" expected to end with "." - remove "."
                 zone_components = public_zone_name.split(".")[::-1]  # reverse order
                 if all(d == z for d, z in zip(domain_components, zone_components)):
+                    # zones that match the shortest comparison considered a candidate
                     candidate_zones[public_zone_name] = zone["Id"]
 
         if candidate_zones:

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -3202,8 +3202,14 @@ class Zappa:
 
         zones = {zone["Name"][:-1]: zone["Id"] for zone in public_zones if zone["Name"][:-1] in domain}
         if zones:
-            keys = max(zones.keys(), key=lambda a: len(a))  # get longest key -- best match.
-            return zones[keys]
+            domain_components = domain.split(".")[::-1]  # match in reverse
+            matches = []
+            for zone in zones:
+                zone_components = zone.split(".")[::-1]  # match in reverse
+                match_count = sum(d == z for d, z in zip(domain_components, zone_components))
+                matches.append((zone, match_count))
+            key, _ = max(matches, key=lambda a: a[1])  # get key with most matches
+            return zones[key]
         else:
             return None
 

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -22,7 +22,6 @@ import time
 import uuid
 import zipfile
 from builtins import bytes, int
-from itertools import zip_longest
 from distutils.dir_util import copy_tree
 from io import open
 from typing import Optional

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -3208,8 +3208,8 @@ class Zappa:
                     candidate_zones[public_zone_name] = zone["Id"]
 
         if candidate_zones:
-            key = max(candidate_zones.keys(), key=lambda a: len(a))  # get longest key -- best match.
-            return candidate_zones[key]
+            best_match_key = max(candidate_zones.keys(), key=lambda a: len(a))  # get longest key -- best match.
+            return candidate_zones[best_match_key]
         else:
             return None
 


### PR DESCRIPTION
## Description
Current `get_best_match_zone()` chooses the best match by length, so the expectation will result in error where a match is a partial match.

When zones are:

- `example.com`
- `beta.example.com`
 
And `some-beta.example.com` is given as the *domain*, the expected match is `example.com`, but `beta.example.com` will match.

This PR picks the zone with the most matches instead of length

## GitHub Issues
https://github.com/zappa/Zappa/issues/1190

