### PR TITLE
fix FileNotFoundError in running_in_docker (#1201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zappa Changelog
 
+## 0.56.1
+
+* FileNotFoundError in running_in_docker (#1201)
+
 ## 0.56.0
 * Not recognizing virtaulenv created with pyenv (#1132)
 * Remove six from zappa dependencies (#1164)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2626,6 +2626,19 @@ class TestZappa(unittest.TestCase):
         except RuntimeError:
             self.fail()
 
+    @mock.patch("pathlib.Path.exists", return_value=False)
+    @mock.patch("pathlib.Path.read_text", side_effect=FileNotFoundError("not found"))
+    @mock.patch("sys.version_info", new_callable=partial(get_sys_versioninfo, 7))
+    def test_running_in_docker_filenotfound(self, *_):
+        from importlib import reload
+
+        try:
+            import zappa
+
+            reload(zappa)
+        except FileNotFoundError:
+            self.fail()
+
     def test_wsgi_query_string_unquoted(self):
         event = {
             "body": {},

--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -8,8 +8,11 @@ def running_in_docker() -> bool:
     - When docker is used allow usage of any python version
     """
     # https://stackoverflow.com/a/20012536/24718
-    cgroup_content = Path("/proc/1/cgroup").read_text()
-    in_docker = "/docker/" in cgroup_content or "/lxc/" in cgroup_content
+    in_docker = False
+    cgroup_filepath = Path("/proc/1/cgroup")
+    if cgroup_filepath.exists():
+        cgroup_content = cgroup_filepath.read_text(encoding="utf8")
+        in_docker = "/docker/" in cgroup_content or "/lxc/" in cgroup_content
     return in_docker
 
 
@@ -33,4 +36,4 @@ elif running_in_docker() and sys.version_info.minor < MINIMUM_SUPPORTED_MINOR_VE
     raise RuntimeError(err_msg)
 
 
-__version__ = "0.56.0"
+__version__ = "0.56.1"


### PR DESCRIPTION
running_in_docker() check introduced in 0.56.0, and assumes that `/proc/1/cgroup` is always on the system (linux system assumed), this PR updates to check for the expected file existence before attempting to read it's content.

- :bug: fix running_in_docker()
- :arrow_up: increments version to 0.56.1
- :pencil: updates CHANGELOG.md with 0.56.1 and with #1201


Fixes:
- FileNotFoundError in running_in_docker (#1201)
