### PR TITLE
updating workflow actions to remove deprecation warnings

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: Install `pypa/build`

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,12 +14,12 @@ jobs:
         python: [3.7, 3.8, 3.9, "3.10"]
     steps:
       - name: Checkout Code Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip${{ matrix.python }}-${{ hashFiles('Pipfile') }}
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
       - name: Finalise Coverage
         run: pip3 install --upgrade coveralls && coveralls --service=github --finish
         env:


### PR DESCRIPTION
- actions/checkout from v2 to v3
- actions/setup-python from v2 to v4
- actions/cache from v2 to v3

Examples of warnings here: https://github.com/zappa/Zappa/actions/runs/4910474756