### PR TITLE
Add Support for Manylinux 2_28 build libraries

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -317,8 +317,8 @@ class Zappa:
         else:
             self.manylinux_suffix_start = "cp310"
 
-        # AWS Lambda supports manylinux1/2010, manylinux2014, and manylinux_2_24
-        manylinux_suffixes = ("_2_24", "2014", "2010", "1")
+        # AWS Lambda supports manylinux1/2010, manylinux2014, manylinux_2_24, and manylinux_2_28
+        manylinux_suffixes = ("_2_28", "_2_24", "2014", "2010", "1")
         self.manylinux_wheel_file_match = re.compile(
             rf'^.*{self.manylinux_suffix_start}-(manylinux_\d+_\d+_x86_64[.])?manylinux({"|".join(manylinux_suffixes)})_x86_64[.]whl$'  # noqa: E501
         )


### PR DESCRIPTION
Had added support for Manylinux 2_24 in 2021:
https://github.com/zappa/Zappa/pull/1083

But that version is EoL and Python Cryptography has moved to Manylinux 2_28.
https://github.com/pypa/manylinux

Updating to support while maintaining backwards compatibility.

Tested on Lambda an encountered no issues

<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/zappa/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.7**, **Python 3.8**, **Python 3.9** and **Python 3.10** ?

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

