### PR TITLE
:pencil: CHANGELOG.md update for 0.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Zappa Changelog
 
+## 0.57.0
+
+* Python 3.10 support (#1124, #1160)
+* Remove patron link from README (#1200)
+* migrate test framework from nose to pytest (#1146)
+* Upgrading Django to 4.2 crashes the zappa based deployment with Error 500 (#1230)
+
 ## 0.56.1
 
 * Fix FileNotFoundError in running_in_docker (#1201)

--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -30,4 +30,4 @@ elif running_in_docker() and sys.version_info.minor < MINIMUM_SUPPORTED_MINOR_VE
     )
     raise RuntimeError(err_msg)
 
-__version__ = "0.56.1"
+__version__ = "0.57.0"


### PR DESCRIPTION
## Description

CHANGELOG.md update for next release.

## GitHub Issues

* Python 3.10 support (#1124, #1160)
* Remove patron link from README (#1200)
* migrate test framework from nose to pytest (#1146)
* Upgrading Django to 4.2 crashes the zappa based deployment with Error 500 (#1230)
