### PR TITLE
update manylinux wheels download logic

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -231,15 +231,15 @@ class TestZappa(unittest.TestCase):
                 "2.1.3": [
                     {
                         "url": "https://files.pythonhosted.org/packages/a6/56/f1d4ee39e898a9e63470cbb7fae1c58cce6874f25f54220b89213a47f273/MarkupSafe-2.1.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-                        "filename": "MarkupSafe-2.1.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+                        "filename": "MarkupSafe-2.1.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
                     },
                     {
                         "url": "https://files.pythonhosted.org/packages/12/b3/d9ed2c0971e1435b8a62354b18d3060b66c8cb1d368399ec0b9baa7c0ee5/MarkupSafe-2.1.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-                        "filename": "MarkupSafe-2.1.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+                        "filename": "MarkupSafe-2.1.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
                     },
                     {
                         "url": "https://files.pythonhosted.org/packages/bf/b7/c5ba9b7ad9ad21fc4a60df226615cf43ead185d328b77b0327d603d00cc5/MarkupSafe-2.1.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
-                        "filename": "MarkupSafe-2.1.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+                        "filename": "MarkupSafe-2.1.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
                     },
                 ]
             }
@@ -251,8 +251,7 @@ class TestZappa(unittest.TestCase):
 
         self.assertEqual(file_name, expected_filename)
         mock_get.assert_called_once_with(
-            "https://pypi.python.org/pypi/markupsafe/json",
-            timeout=float(os.environ.get("PIP_TIMEOUT", 1.5))
+            "https://pypi.python.org/pypi/markupsafe/json", timeout=float(os.environ.get("PIP_TIMEOUT", 1.5))
         )
 
         # Clean the generated files

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -245,7 +245,7 @@ class TestZappa(unittest.TestCase):
             }
         }
 
-        with mock.patch("requests.get") as mock_get:
+        with mock.patch("zappa.core.requests.get") as mock_get:
             mock_get.return_value.json.return_value = mock_package_data
             wheel_url, file_name = z.get_manylinux_wheel_url("markupsafe", "2.1.3")
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -247,12 +247,12 @@ class TestZappa(unittest.TestCase):
 
         with mock.patch("zappa.core.requests.get") as mock_get:
             mock_get.return_value.json.return_value = mock_package_data
-            wheel_url, file_name = z.get_manylinux_wheel_url("markupsafe", "2.1.3")
+            wheel_url, file_name = z.get_manylinux_wheel_url("markupsafe", "2.1.3", ignore_cache=True)
 
-        self.assertEqual(file_name, expected_filename)
-        mock_get.assert_called_once_with(
-            "https://pypi.python.org/pypi/markupsafe/json", timeout=float(os.environ.get("PIP_TIMEOUT", 1.5))
-        )
+            self.assertEqual(file_name, expected_filename)
+            mock_get.assert_called_once_with(
+                "https://pypi.python.org/pypi/markupsafe/json", timeout=float(os.environ.get("PIP_TIMEOUT", 1.5))
+            )
 
         # Clean the generated files
         cached_pypi_info_dir = os.path.join(tempfile.gettempdir(), "cached_pypi_info")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -197,6 +197,31 @@ class TestZappa(unittest.TestCase):
             self.assertTrue(os.path.isfile(path))
             os.remove(path)
 
+    def test_verify_python37_does_not_download_2_24_manylinux_wheel(self):
+        z = Zappa(runtime="python3.7")
+        cached_wheels_dir = os.path.join(tempfile.gettempdir(), "cached_wheels")
+        expected_wheel_path = os.path.join(
+            cached_wheels_dir, "cryptography-35.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+        )
+
+        # Check with known manylinux wheel package
+        actual_wheel_path = z.get_cached_manylinux_wheel("cryptography", "35.0.0")
+        self.assertEqual(actual_wheel_path, expected_wheel_path)
+        os.remove(actual_wheel_path)
+
+    def test_verify_downloaded_manylinux_wheel(self):
+        z = Zappa(runtime="python3.10")
+        cached_wheels_dir = os.path.join(tempfile.gettempdir(), "cached_wheels")
+        expected_wheel_path = os.path.join(
+            cached_wheels_dir,
+            "pycryptodome-3.16.0-cp35-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
+        )
+
+        # check with a known manylinux wheel package
+        actual_wheel_path = z.get_cached_manylinux_wheel("pycryptodome", "3.16.0")
+        self.assertEqual(actual_wheel_path, expected_wheel_path)
+        os.remove(actual_wheel_path)
+
     def test_getting_installed_packages(self, *args):
         z = Zappa(runtime="python3.7")
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -222,6 +222,14 @@ class TestZappa(unittest.TestCase):
         self.assertEqual(actual_wheel_path, expected_wheel_path)
         os.remove(actual_wheel_path)
 
+    def test_verify_manylinux_filename_is_lowered(self):
+        z = Zappa(runtime="python3.10")
+        expected_filename = "markupsafe-2.1.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+
+        # check with a known manylinux wheel package MarkupSafe with capital case letters
+        wheel_url, file_name = z.get_manylinux_wheel_url("markupsafe", "2.1.3")
+        self.assertEqual(file_name, expected_filename)
+
     def test_getting_installed_packages(self, *args):
         z = Zappa(runtime="python3.7")
 

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -989,11 +989,13 @@ class Zappa:
 
         for f in data["releases"][package_version]:
             if re.match(self.manylinux_wheel_file_match, f["filename"]):
-                return f["url"], f["filename"]
+                # Since we have already lowered package names in get_installed_packages
+                # manylinux caching is not working for packages with capital case in names like MarkupSafe
+                return f["url"], f["filename"].lower()
             elif re.match(self.manylinux_wheel_abi3_file_match, f["filename"]):
                 for manylinux_suffix in self.manylinux_suffixes:
                     if f"manylinux{manylinux_suffix}_x86_64" in f["filename"]:
-                        return f["url"], f["filename"]
+                        return f["url"], f["filename"].lower()
         return None, None
 
     ##

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -994,7 +994,6 @@ class Zappa:
                 for manylinux_suffix in self.manylinux_suffixes:
                     if f"manylinux{manylinux_suffix}_x86_64" in f["filename"]:
                         return f["url"], f["filename"]
-                return f["url"], f["filename"]
         return None, None
 
     ##

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -24,8 +24,8 @@ import zipfile
 from builtins import bytes, int
 from distutils.dir_util import copy_tree
 from io import open
-from typing import Optional
 from pathlib import Path
+from typing import Optional
 
 import boto3
 import botocore

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -925,12 +925,12 @@ class Zappa:
 
             for pathname in glob.iglob(wheel_path):
                 if re.match(self.manylinux_wheel_file_match, pathname):
-                    print(f" - {package_name}=={package_version}: Using locally cached manylinux wheel")
+                    logger.info(f" - {package_name}=={package_version}: Using locally cached manylinux wheel")
                     return pathname
                 elif re.match(self.manylinux_wheel_abi3_file_match, pathname):
                     for manylinux_suffix in self.manylinux_suffixes:
                         if f"manylinux{manylinux_suffix}_x86_64" in pathname:
-                            print(f" - {package_name}=={package_version}: Using locally cached manylinux wheel")
+                            logger.info(f" - {package_name}=={package_version}: Using locally cached manylinux wheel")
                             return pathname
 
         # The file is not cached, download it.
@@ -939,7 +939,7 @@ class Zappa:
             return None
 
         wheel_path = os.path.join(cached_wheels_dir, filename)
-        print(f" - {package_name}=={package_version}: Downloading")
+        logger.info(f" - {package_name}=={package_version}: Downloading")
         with open(wheel_path, "wb") as f:
             self.download_url_with_progress(wheel_url, f, disable_progress)
 


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/zappa/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.7**, **Python 3.8**, **Python 3.9** and **Python 3.10** ?

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
The current manylinux regex is not matching some wheel files. Updated the Manylinux wheels download logic to fix this.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
https://github.com/zappa/Zappa/issues/1249
https://github.com/zappa/Zappa/issues/1063

