### PR TITLE
Never use root logger to allow filtering zappa logs with greater ease

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -30,7 +30,7 @@ except ImportError:  # pragma: no cover
 
 # Set up logging
 logging.basicConfig()
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -168,7 +168,7 @@ def common_log(environ, response, response_time: Optional[int] = None):
     response_time: response time in micro-seconds
     """
 
-    logger = logging.getLogger()
+    logger = logging.getLogger(__name__)
 
     if response_time:
         formatter = ApacheNCSAFormatter(with_response_time=True)


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/zappa/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.7**, **Python 3.8**, **Python 3.9**, **Python 3.10** and **Python 3.11** ?

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
It is a simple change to avoid using the root logger, so that upstream application can easily decide how to handle these specific logs while leaving root logger untouched.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

