### PR TITLE
add keep_policies config to prevent Zappa from removing resource policy

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -117,6 +117,7 @@ class ZappaCLI:
     environment_variables = None
     authorizer = None
     xray_tracing = False
+    keep_policies = None
     aws_kms_key_arn = ""
     context_header_mappings = None
     additional_text_mimetypes = None
@@ -2295,6 +2296,7 @@ class ZappaCLI:
         self.aws_kms_key_arn = self.stage_config.get("aws_kms_key_arn", "")
         self.context_header_mappings = self.stage_config.get("context_header_mappings", {})
         self.xray_tracing = self.stage_config.get("xray_tracing", False)
+        self.keep_policies = self.stage_config.get('keep_policies', None)
         self.desired_role_arn = self.stage_config.get("role_arn")
         self.layers = self.stage_config.get("layers", None)
         self.additional_text_mimetypes = self.stage_config.get("additional_text_mimetypes", None)
@@ -2322,6 +2324,7 @@ class ZappaCLI:
             tags=self.tags,
             endpoint_urls=self.stage_config.get("aws_endpoint_urls", {}),
             xray_tracing=self.xray_tracing,
+            keep_policies=self.keep_policies
         )
 
         for setting in CUSTOM_SETTINGS:

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2752,7 +2752,7 @@ class Zappa:
                 for s in statement:
                     sid = s['Sid']
                     if self.keep_policies:
-                        if not (self.keep_policies == '*' or (isinstance(self.keep_policies, list) and sid in self.keep_policies) or (isinstance(self.keep_policies, str) and self.keep_policies in sid)):
+                        if self.keep_policies == '*' or (isinstance(self.keep_policies, list) and sid in self.keep_policies) or (isinstance(self.keep_policies, str) and self.keep_policies in sid):
                             # * = keep all
                             # string = keep sids that contain the value
                             # list = keep sids that are in the list (no wildcards)


### PR DESCRIPTION
## Description

This is a small change to ignore certain policies from the pruning that happens in `Zappa._clear_policy`

The context is that my function is attached to a VPC/VPN/private ALB through a secondary configuration. It requires a policy that allows load-balancing, but the policy keeps getting cleared out by Zappa.

This change allows for a simple `keep_policies` configuration that can be set to a list or string for SID matching within the function policy, and is null/disabled by default.