### PR TITLE
Configures 'pre-commit' hooks for Zappa's development tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,45 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    -   id: check-yaml
+    -   id: name-tests-test
+        args: [--unittest]
+        exclude: ^tests/utils.py
+-   repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+    -   id: isort
+        args: [--profile=black, --gitignore]
+-   repo: https://github.com/psf/black
+    rev: 23.10.1
+    hooks:
+    -   id: black
+        args: [--line-length=127]
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+    -   id: flake8
+        args:
+        -   --count
+        -   --max-complexity=55
+        -   --max-line-length=127
+        -   --statistics
+        -   --extend-ignore=E203,E231,E252,E721,F403,F405,F541,W503
+        files: zappa
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.6.1
+    hooks:
+    -   id: mypy
+        args:
+        -   --show-error-codes
+        -   --pretty
+        -   --ignore-missing-imports
+        -   --no-site-packages
+        files: zappa
+-   repo: https://github.com/thlorenz/doctoc
+    rev: v2.2.0
+    hooks:
+    -   id: doctoc
+        args: [--update-only]
+        files: ./README.md

--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ isort = "*"
 mock = "*"
 mypy = "*"
 packaging = "*"
+pre-commit = "*"
 pytest = "*"
 pytest-cov = "*"
 

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -120,7 +120,7 @@ class ZappaCLI:
     aws_kms_key_arn = ""
     context_header_mappings = None
     additional_text_mimetypes = None
-    tags = []
+    tags = []  # type: ignore[var-annotated]
     layers = None
 
     stage_name_env_pattern = re.compile("^[a-zA-Z0-9_]+$")
@@ -2414,14 +2414,14 @@ class ZappaCLI:
         # Create the Lambda zip package (includes project and virtualenvironment)
         # Also define the path the handler file so it can be copied to the zip
         # root for Lambda.
-        current_file = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+        current_file = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))  # type: ignore[arg-type]
         handler_file = os.sep.join(current_file.split(os.sep)[0:]) + os.sep + "handler.py"
 
         # Create the zip file(s)
         if self.stage_config.get("slim_handler", False):
             # Create two zips. One with the application and the other with just the handler.
             # https://github.com/Miserlou/Zappa/issues/510
-            self.zip_path = self.zappa.create_lambda_zip(
+            self.zip_path = self.zappa.create_lambda_zip(  # type: ignore[attr-defined]
                 prefix=self.lambda_name,
                 use_precompiled_packages=self.stage_config.get("use_precompiled_packages", True),
                 exclude=self.stage_config.get("exclude", []),
@@ -2432,11 +2432,11 @@ class ZappaCLI:
 
             # Make sure the normal venv is not included in the handler's zip
             exclude = self.stage_config.get("exclude", [])
-            cur_venv = self.zappa.get_current_venv()
+            cur_venv = self.zappa.get_current_venv()  # type: ignore[attr-defined]
             exclude.append(cur_venv.split("/")[-1])
-            self.handler_path = self.zappa.create_lambda_zip(
+            self.handler_path = self.zappa.create_lambda_zip(  # type: ignore[attr-defined]
                 prefix="handler_{0!s}".format(self.lambda_name),
-                venv=self.zappa.create_handler_venv(use_zappa_release=use_zappa_release),
+                venv=self.zappa.create_handler_venv(use_zappa_release=use_zappa_release),  # type: ignore[attr-defined]
                 handler_file=handler_file,
                 slim_handler=True,
                 exclude=exclude,
@@ -2448,7 +2448,7 @@ class ZappaCLI:
             exclude = self.stage_config.get("exclude", ["boto3", "dateutil", "botocore", "s3transfer", "concurrent"])
 
             # Create a single zip that has the handler and application
-            self.zip_path = self.zappa.create_lambda_zip(
+            self.zip_path = self.zappa.create_lambda_zip(  # type: ignore[attr-defined]
                 prefix=self.lambda_name,
                 handler_file=handler_file,
                 use_precompiled_packages=self.stage_config.get("use_precompiled_packages", True),
@@ -2472,7 +2472,7 @@ class ZappaCLI:
         else:
             handler_zip = self.zip_path
 
-        with zipfile.ZipFile(handler_zip, "a") as lambda_zip:
+        with zipfile.ZipFile(handler_zip, "a") as lambda_zip:  # type: ignore[call-overload]
             settings_s = self.get_zappa_settings_string()
 
             # Copy our Django app into root of our package.


### PR DESCRIPTION
Adds [`pre-commit`](https://pre-commit.com/) hooks for all of the major linting/formatting tools currently used in Zappa development.

Two choices I intentionally made to keep the scope of this PR small, low-risk, and easy to review:

1. I specifically tried to keep the behavior of the `pre-commit` hooks to remain as close as possible to the currently defined behavior of the tools in our `MAKEFILE`, even though, in many cases, that behavior is sub-optimal, or even, in some cases, entirely useless (for example, our `MAKEFILE` has `flake8` currently running with the `--exit-zero` arg always enabled, meaning that our CI always thinks it succeeds, despite the fact that `flake8` does, in fact, not actually _ever_ succeed when currently run on our repo and in fact, ends up finding a number of errors that this `MAKEFILE` configuration has hidden for... likely years at this point).  I plan on properly configuring our dev tools to actually provide the value they are meant to in follow up PRs.
2. I also specifically decided to not make any changes to the actual Python code powering Zappa in this PR.  The _only_ changes this PR makes to `.py` files are adding comments that instruct `mypy` to ignore certain lines that don't currently pass `mypy`'s checks.  Again, modernizing the codebase to better conform to all of the best practices imposed by tools like `flake8` and `mypy` can wind up being massive undertakings on big, old, largely untyped codebases like ours that have seemingly never prioritized best practices too highly... So, I wanted to leave any code changes for the sake of pleasing our linting tools (and, thereby hopefully making our code much more readable and easy to follow) to be done via separate PR(s) as well so this one could be safely merged and begin making our contributors' lives easier sooner rather than later.

For more, see Issue #1282, which will be resolved by this PR.