### PR TITLE
Adds automated handling of inactive issues/PRs (dry-run)

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,41 @@
+name: Perform automated repository maintenance
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */2 * * *"
+
+jobs:
+  cleanup-inactive:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    env:
+      inactive_days: 90
+      closing_days: 10
+      total_days: 100
+      inactive_label: "no-activity"
+      closed_label: "auto-closed"
+    steps:
+      - name: Cleanup inactive issues/PRs
+        uses: actions/stale@v9
+        with:
+          days-before-stale: ${{ env.inactive_days }}
+          days-before-close: ${{ env.close_days }}
+          stale-issue-label: ${{ env.inactive_label }}
+          close-issue-label: ${{ env.closed_label }}
+          exempt-issue-labels: "needs-review,planned,in-progress"
+          stale-issue-message: "Hi there! Unfortunately, this Issue has not seen any activity for at least ${{ env.inactive_days }} days. If the Issue is still relevant to the [latest version of Zappa](https://github.com/zappa/Zappa/releases/latest), please comment within the next ${{ env.closing_days }} days if you wish to keep it open. Otherwise, it will be automatically closed."
+          close-issue-message: "Hi there! Unfortunately, this Issue was automatically closed as it had not seen any activity in at least ${{ env.total_days }} days. If the Issue is still relevant to the [latest version of Zappa](https://github.com/zappa/Zappa/releases/latest), please [open a new Issue](https://github.com/zappa/Zappa/issues/new)."
+          stale-pr-label: ${{ env.inactive_label }}
+          close-pr-label: ${{ env.closed_label }}
+          exempt-pr-labels: "needs-review"
+          stale-pr-message: "Hi there! Unfortunately, this PR has not seen any activity for at least ${{ env.inactive_days }} days. If the PR is still relevant to the [latest version of Zappa](https://github.com/zappa/Zappa/releases/latest), please comment within the next ${{ env.closing_days }} days if you wish to keep it open. Otherwise, it will be automatically closed."
+          close-pr-message: "Hi there! Unfortunately, this PR was automatically closed as it had not seen any activity in at least ${{ env.total_days }} days. If the PR is still relevant to the [latest version of Zappa](https://github.com/zappa/Zappa/releases/latest), please [open a new PR](https://github.com/zappa/Zappa/compare)."
+          labels-to-add-when-unstale: "needs-review"
+          ascending: true
+          enable-statistics: true
+          # DEBUG OPTIONS
+          debug-only: true
+          operations-per-run: 1000


### PR DESCRIPTION
## Description
FYI, Zappa turns 8 years old on January 20th! 🎂

Unfortunately, that also means we have a lot of Issues/PRs migrated from the original repo that are nearly that old too.  As a result, we currently have an unwieldy mess of a backlog that makes it difficult to properly prioritize and evaluate Issues/PRs and whether they still are relevant after, in many cases, several _years_ of new Zappa releases.  Manually triaging this kind of historical backlog would take up a lot of time and result in few actionable items.

So, in the interest of reducing both the maintenance load and clutter in this repo, this PR adds a bot that will identify Issues/PRs that haven't seen any activity in at least 90 days (~3 months), and will leave a comment to inform the author (and/or any other interested users) that they can add a comment within 10 days to keep the Issue/PR open (and, if they do so, the bot will label it as needing attention from Zappa's maintainers).

However, if _no_ comment is added within 10 days (which I imagine will be the case for the vast majority of our multi-year old Issues/PRs), then the bot will automatically close it to reduce clutter (while again leaving a helpful comment for users who may find the closed Issue/PR in the future that instructs them to open a new Issue/PR if they find it's still relevant).

**Note:** This PR introduces this bot in "dry-run"/"debug mode", which means it won't actually make any changes, but will log what changes it _would_ have made.  Letting it go through a few dry-runs first will provide us with data that will show us if it is behaving as intended.  If not, the config can be tweaked, but, if so, "debug mode" can be turned off so this bot can begin helping us create a more organized repo with a more manageable backlog for 2024. 🎉