### PR TITLE
Fix line that was missed when dropping Py3.7 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     version=__version__,
     packages=["zappa"],
     install_requires=required,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     tests_require=test_required,
     include_package_data=True,
     license="MIT License",


### PR DESCRIPTION
## Description
A single (but rather important) line was missed in #1292, which, if not corrected, may allow package managers to install any new releases of Zappa on Py3.7, even though all logic needed to support Py3.7 has now been removed from Zappa.

This PR is a 1-line (1-char, to be precise 🙃) fix which must be merged before any new release of Zappa can be published.