### PR TITLE
Fix typo breaking new automation for handling inactive issues/PRs

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/stale@v9
         with:
           days-before-stale: ${{ env.inactive_days }}
-          days-before-close: ${{ env.close_days }}
+          days-before-close: ${{ env.closing_days }}
           stale-issue-label: ${{ env.inactive_label }}
           close-issue-label: ${{ env.closed_label }}
           exempt-issue-labels: "needs-review,planned,in-progress"


### PR DESCRIPTION
#1296 had a typo which has caused the new GitHub action it added to [constantly fail](https://github.com/zappa/Zappa/actions/workflows/maintenance.yml).  This fixes the typo, which should allow the action to run successfully (in debug/"dry-run" mode).