### PR TITLE
Provide a fix for the module importer, deprecated `find_module` in Python 3.12

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2141,7 +2141,10 @@ class ZappaCLI:
                     working_dir = os.getcwd()
 
                 working_dir_importer = pkgutil.get_importer(working_dir)
-                module_ = working_dir_importer.find_module(mod_name).load_module(mod_name)
+                if self.runtime == "python3.12":
+                    module_ = working_dir_importer.find_spec(mod_name).loader.load_module(mod_name)
+                else:
+                    module_ = working_dir_importer.find_module(mod_name).load_module(mod_name)
 
             except (ImportError, AttributeError):
                 try:  # Callback func might be in virtualenv
@@ -2844,7 +2847,10 @@ class ZappaCLI:
                 working_dir = os.getcwd()
 
             working_dir_importer = pkgutil.get_importer(working_dir)
-            module_ = working_dir_importer.find_module(mod_name).load_module(mod_name)
+            if self.runtime == "python3.12":
+                module_ = working_dir_importer.find_spec(mod_name).loader.load_module(mod_name)
+            else:
+                module_ = working_dir_importer.find_module(mod_name).load_module(mod_name)
 
         except (ImportError, AttributeError):
             try:  # Prebuild func might be in virtualenv


### PR DESCRIPTION
## Description

Deprecated `find_module` in Python 3.12, triggered when executing pre or post build scripts.
This PR fixes the issue

Ref: #1291, #1292