### PR TITLE
Run repo maintenance every 30 mins instead of every 2 hrs to increase throughput

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -10,7 +10,7 @@ on:
         description: "Max number of operations per run"
         type: number
   schedule:
-    - cron: "0 */2 * * *"
+    - cron: "*/30 * * * *"
 
 jobs:
   cleanup-inactive:


### PR DESCRIPTION
This change was intended to be committed as part of the "speed up tweaks" mentioned in #1322; analysis of the logs from the manual runs showed running batches of 200 operations every 30 minutes was approximately the sweet spot to maximize processing throughput while ensuring sufficient margin is maintained to safely avoid hitting any GitHub rate limits.  GitHub rate limits reset hourly, therefore running the job every 2 hours limits the maximum processing throughput of the workflow by at least 50%.