### PR TITLE
Remove deprecated zappa.async module

### DIFF
--- a/zappa/async.py
+++ b/zappa/async.py
@@ -1,8 +1,0 @@
-import warnings
-
-from .asynchronous import *  # noqa: F401
-
-warnings.warn(
-    'Module "zappa.async" is deprecated; please use "zappa.asynchronous" instead.',
-    category=DeprecationWarning,
-)


### PR DESCRIPTION
[`async` has been a Python keyword since Py3.5](https://peps.python.org/pep-0492/), which we dropped support for _several years ago_, so the `zappa.async` module hasn't been usable in a long time.  Removing it to avoid confusion and because the error-checking recently added in our [new build process](https://github.com/zappa/Zappa/pull/1324) is [preventing us from building a package containing a module that shares the name of a Python keyword](https://github.com/zappa/Zappa/actions/runs/8635644657/job/23673842361#step:3:381) (as it should, as such modules would fail to import).