### PR TITLE
:bug: :wrench: fix Zappa.create_handler_venv win32 case wherestderror_result is None

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2634,11 +2634,10 @@ class TestZappa(unittest.TestCase):
         expected = "query=Jane%26John&otherquery=B&test=hello%2Bm.te%26how%26are%26you"
         self.assertEqual(request["QUERY_STRING"], expected)
 
-    @mock.patch()
-    @mock.patch(subprocess.Popen)
+    @mock.patch("subprocess.Popen")
     def test_create_handler_venv_win32_none_stderror_result(self, popen_mock):
         class PopenMock:
-            return_code = 999
+            returncode = 999
 
             @classmethod
             def communicate(cls):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2634,6 +2634,32 @@ class TestZappa(unittest.TestCase):
         expected = "query=Jane%26John&otherquery=B&test=hello%2Bm.te%26how%26are%26you"
         self.assertEqual(request["QUERY_STRING"], expected)
 
+    @mock.patch()
+    @mock.patch(subprocess.Popen)
+    def test_create_handler_venv_win32_none_stderror_result(self, popen_mock):
+
+        class PopenMock:
+            return_code = 999
+
+            @classmethod
+            def communicate(cls):
+                return "valid_stdout", None  # On win32, stderr can be None
+
+
+        popen_mock.return_value = PopenMock
+
+        boto_mock = mock.MagicMock()
+        zappa_core = Zappa(
+            boto_session=boto_mock,
+            profile_name="test",
+            aws_region="test",
+            load_credentials=True,
+        )
+
+        with self.assertRaises(EnvironmentError):
+            zappa_core.create_handler_venv()
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2637,14 +2637,12 @@ class TestZappa(unittest.TestCase):
     @mock.patch()
     @mock.patch(subprocess.Popen)
     def test_create_handler_venv_win32_none_stderror_result(self, popen_mock):
-
         class PopenMock:
             return_code = 999
 
             @classmethod
             def communicate(cls):
                 return "valid_stdout", None  # On win32, stderr can be None
-
 
         popen_mock.return_value = PopenMock
 
@@ -2658,7 +2656,6 @@ class TestZappa(unittest.TestCase):
 
         with self.assertRaises(EnvironmentError):
             zappa_core.create_handler_venv()
-
 
 
 if __name__ == "__main__":

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -310,7 +310,7 @@ class Zappa:
         self.manylinux_wheel_file_match = re.compile(
             rf'^.*{self.manylinux_suffix_start}-(manylinux_\d+_\d+_x86_64[.])?manylinux({"|".join(self.manylinux_suffixes)})_x86_64[.]whl$'  # noqa: E501
         )
-        self.manylinux_wheel_abi3_file_match = re.compile(rf"^.*cp3.-abi3-manylinux.*_x86_64[.]whl$")
+        self.manylinux_wheel_abi3_file_match = re.compile(r"^.*cp3.-abi3-manylinux.*_x86_64[.]whl$")
 
         self.endpoint_urls = endpoint_urls
         self.xray_tracing = xray_tracing

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -488,9 +488,9 @@ class Zappa:
 
         if pip_return_code:
             logger.info("command: %s", " ".join(command))
-            if stdout_result.strip():
+            if stdout_result and stdout_result.strip():
                 logger.info("stdout: %s", stdout_result.strip())
-            if stderror_result.strip():
+            if stderror_result and stderror_result.strip():
                 logger.error("stderr: %s", stderror_result)
             raise EnvironmentError("Pypi lookup failed")
 

--- a/zappa/middleware.py
+++ b/zappa/middleware.py
@@ -44,7 +44,11 @@ class ZappaWSGIMiddleware:
             Related: https://github.com/Miserlou/Zappa/issues/1965
             """
 
-            new_headers = [header for header in headers if ((type(header[0]) != str) or (header[0].lower() != "set-cookie"))]
+            new_headers = [
+                header
+                for header in headers
+                if ((type(header[0]) != str) or (header[0].lower() != "set-cookie"))
+            ]
             cookie_headers = [
                 (header[0].lower(), header[1])
                 for header in headers

--- a/zappa/middleware.py
+++ b/zappa/middleware.py
@@ -47,12 +47,12 @@ class ZappaWSGIMiddleware:
             new_headers = [
                 header
                 for header in headers
-                if ((type(header[0]) != str) or (header[0].lower() != "set-cookie"))
+                if isinstance(header[0], str) or header[0].lower() != "set-cookie"
             ]
             cookie_headers = [
                 (header[0].lower(), header[1])
                 for header in headers
-                if ((type(header[0]) == str) and (header[0].lower() == "set-cookie"))
+                if isinstance(header[0], str) and header[0].lower() == "set-cookie"
             ]
             new_headers = new_headers + cookie_headers
 

--- a/zappa/middleware.py
+++ b/zappa/middleware.py
@@ -44,11 +44,7 @@ class ZappaWSGIMiddleware:
             Related: https://github.com/Miserlou/Zappa/issues/1965
             """
 
-            new_headers = [
-                header
-                for header in headers
-                if isinstance(header[0], str) or header[0].lower() != "set-cookie"
-            ]
+            new_headers = [header for header in headers if isinstance(header[0], str) or header[0].lower() != "set-cookie"]
             cookie_headers = [
                 (header[0].lower(), header[1])
                 for header in headers


### PR DESCRIPTION
## Description

Update `Zappa.create_handler_venv`, so that when the result from `pip_process.communicate()` returns `None` for _stderr_, an unrelated exception is NOT raised, and `zappa.create_handler_venv` proceeds as expected.

Currently, the code assumes a str value is returned, but on `win32` systems, it appears that `None` may be returned.

## GitHub Issues

#1342

