### PR TITLE
Add support for Python 3.13 in templates, CI, and codebase

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,28 +1,37 @@
 <!--- Provide a general summary of the issue in the Title above -->
+
 ## Context
+
 <!--- Provide a more detailed introduction to the issue itself, and why you consider it to be a bug -->
-<!--- Also, please make sure that you are running Zappa _from a virtual environment_ and are using Python 3.8/3.9/3.10/3.11/3.12 -->
+<!--- Also, please make sure that you are running Zappa _from a virtual environment_ and are using Python 3.8/3.9/3.10/3.11/3.12/3.13 -->
 
 ## Expected Behavior
+
 <!--- Tell us what should happen -->
 
 ## Actual Behavior
+
 <!--- Tell us what happens instead -->
 
 ## Possible Fix
+
 <!--- Not obligatory, but suggest a fix or reason for the bug -->
 
 ## Steps to Reproduce
+
 <!--- Provide a link to a live example, or an unambiguous set of steps to -->
 <!--- reproduce this bug include code to reproduce, if relevant -->
+
 1.
 2.
 3.
 
 ## Your Environment
+
 <!--- Include as many relevant details about the environment you experienced the bug in -->
-* Zappa version used:
-* Operating System and Python version:
-* The output of `pip freeze`:
-* Link to your project (optional):
-* Your `zappa_settings.json`: 
+
+- Zappa version used:
+- Operating System and Python version:
+- The output of `pip freeze`:
+- Link to your project (optional):
+- Your `zappa_settings.json`:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ Before you submit this PR, please make sure that you meet these criteria:
 
 * Did you **make sure this code actually works on Lambda**, as well as locally?
 
-* Did you test this code with all of: **Python 3.8**, **Python 3.9**, **Python 3.10**, **Python 3.11**, and **Python 3.12**?
+* Did you test this code with all of: **Python 3.8**, **Python 3.9**, **Python 3.10**, **Python 3.11**, **Python 3.12**, and **Python 3.13**?
 
 * Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?
 
@@ -31,9 +31,10 @@ Thank you for your contribution!
 -->
 
 ## Description
-<!-- Please describe the changes included in this PR --> 
+
+<!-- Please describe the changes included in this PR -->
 
 ## GitHub Issues
+
 <!-- Proposed changes should be discussed in an issue before submitting a PR. -->
 <!-- Link to relevant tickets here. -->
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on:  # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   pull_request:
     branches: ["master"]
   push:
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: isort
         args: [--profile=black, --gitignore]
 -   repo: https://github.com/psf/black
-    rev: 24.1.1
+    rev: 25.1.0
     hooks:
     -   id: black
         args: [--line-length=127]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: isort
         args: [--profile=black, --gitignore]
 -   repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 24.8.0
     hooks:
     -   id: black
         args: [--line-length=127]

--- a/Pipfile
+++ b/Pipfile
@@ -4,10 +4,10 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-black = "==24.1.1"
+black = "==25.1.0"
 boto3-stubs = "*"
 coveralls = "*"
-Django = "<4"
+django = ">4,<6"
 django-stubs = "*"
 flake8 = "==7.0.0"
 Flask = "*"
@@ -18,6 +18,7 @@ packaging = "*"
 pre-commit = "*"
 pytest = "*"
 pytest-cov = "*"
+legacy-cgi = "*"
 
 [packages]
 argcomplete = "*"
@@ -26,20 +27,18 @@ durationpy = "*"
 hjson = "*"
 jmespath = "*"
 kappa = "==0.6.0"
-pip = ">=9.0.1"
-# Workaround until tests are updated to work with 'placebo' 0.10
-# Move to 'dev-packages' when unpinned
+pip = ">=24.0.0"
 placebo = "<0.10"
 python-dateutil = "*"
 python-slugify = "*"
 PyYAML = "*"
-# previous versions don't work with urllib3 1.24
-requests = ">=2.20.0"
+requests = ">=2.32.0"
 toml = "*"
-tqdm = "*"
+tqdm = ">=4.66.3"
 troposphere = ">=3.0"
 Werkzeug = "*"
 wheel = "*"
+setuptools = "*"
 
 [pipenv]
 allow_prereleases = false

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-black = "==25.1.0"
+black = "==24.8.0"
 boto3-stubs = "*"
 coveralls = "*"
 django = ">4,<6"

--- a/README.md
+++ b/README.md
@@ -986,7 +986,7 @@ to change Zappa's behavior. Use these at your own risk!
         "role_name": "MyLambdaRole", // Name of Zappa execution role. Default <project_name>-<env>-ZappaExecutionRole. To use a different, pre-existing policy, you must also set manage_roles to false.
         "role_arn": "arn:aws:iam::12345:role/app-ZappaLambdaExecutionRole", // ARN of Zappa execution role. Default to None. To use a different, pre-existing policy, you must also set manage_roles to false. This overrides role_name. Use with temporary credentials via GetFederationToken.
         "route53_enabled": true, // Have Zappa update your Route53 Hosted Zones when certifying with a custom domain. Default true.
-        "runtime": "python3.12", // Python runtime to use on Lambda. Can be one of: "python3.8", "python3.9", "python3.10", "python3.11", "python3.12", or "python3.13". Defaults to whatever the current Python being used is.
+        "runtime": "python3.13", // Python runtime to use on Lambda. Can be one of: "python3.8", "python3.9", "python3.10", "python3.11", "python3.12", or "python3.13". Defaults to whatever the current Python being used is.
         "s3_bucket": "dev-bucket", // Zappa zip bucket,
         "slim_handler": false, // Useful if project >50M. Set true to just upload a small handler to Lambda and load actual project from S3 at runtime. Default false.
         "settings_file": "~/Projects/MyApp/settings/dev_settings.py", // Server side settings file location,

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ __Awesome!__
 
 ## Installation and Configuration
 
-_Before you begin, make sure you are running Python 3.8/3.9/3.10/3.11/3.12 and you have a valid AWS account and your [AWS credentials file](https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs) is properly installed._
+_Before you begin, make sure you are running Python 3.8/3.9/3.10/3.11/3.12/3.13 and you have a valid AWS account and your [AWS credentials file](https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs) is properly installed._
 
 **Zappa** can easily be installed through pip, like so:
 
@@ -443,7 +443,7 @@ For instance, suppose you have a basic application in a file called "my_app.py",
 
 Any remote print statements made and the value the function returned will then be printed to your local console. **Nifty!**
 
-You can also invoke interpretable Python 3.8/3.9/3.10/3.11/3.12 strings directly by using `--raw`, like so:
+You can also invoke interpretable Python 3.8/3.9/3.10/3.11/3.12/3.13 strings directly by using `--raw`, like so:
 
     $ zappa invoke production "print(1 + 2 + 3)" --raw
 
@@ -986,7 +986,7 @@ to change Zappa's behavior. Use these at your own risk!
         "role_name": "MyLambdaRole", // Name of Zappa execution role. Default <project_name>-<env>-ZappaExecutionRole. To use a different, pre-existing policy, you must also set manage_roles to false.
         "role_arn": "arn:aws:iam::12345:role/app-ZappaLambdaExecutionRole", // ARN of Zappa execution role. Default to None. To use a different, pre-existing policy, you must also set manage_roles to false. This overrides role_name. Use with temporary credentials via GetFederationToken.
         "route53_enabled": true, // Have Zappa update your Route53 Hosted Zones when certifying with a custom domain. Default true.
-        "runtime": "python3.12", // Python runtime to use on Lambda. Can be one of: "python3.8", "python3.9", "python3.10", "python3.11", or "python3.12". Defaults to whatever the current Python being used is.
+        "runtime": "python3.12", // Python runtime to use on Lambda. Can be one of: "python3.8", "python3.9", "python3.10", "python3.11", "python3.12", or "python3.13". Defaults to whatever the current Python being used is.
         "s3_bucket": "dev-bucket", // Zappa zip bucket,
         "slim_handler": false, // Useful if project >50M. Set true to just upload a small handler to Lambda and load actual project from S3 at runtime. Default false.
         "settings_file": "~/Projects/MyApp/settings/dev_settings.py", // Server side settings file location,

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Framework :: Django",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.2",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -236,6 +236,33 @@ class TestZappa(unittest.TestCase):
             path = z.create_lambda_zip(handler_file=os.path.realpath(__file__))
             self.assertTrue(os.path.isfile(path))
             os.remove(path)
+            
+    def test_get_manylinux_python313(self):
+        z = Zappa(runtime="python3.13")
+        self.assertIsNotNone(z.get_cached_manylinux_wheel("psycopg-binary", "3.1.17"))
+        self.assertIsNone(z.get_cached_manylinux_wheel("derp_no_such_thing", "0.0"))
+
+        # mock with a known manylinux wheel package so that code for downloading them gets invoked
+        mock_installed_packages = {"psycopg-binary": "3.1.17"}
+        with mock.patch(
+            "zappa.core.Zappa.get_installed_packages",
+            return_value=mock_installed_packages,
+        ):
+            z = Zappa(runtime="python3.13")
+            path = z.create_lambda_zip(handler_file=os.path.realpath(__file__))
+            self.assertTrue(os.path.isfile(path))
+            os.remove(path)
+
+        # same, but with an ABI3 package
+        mock_installed_packages = {"cryptography": "41.0.7"}
+        with mock.patch(
+            "zappa.core.Zappa.get_installed_packages",
+            return_value=mock_installed_packages,
+        ):
+            z = Zappa(runtime="python3.13")
+            path = z.create_lambda_zip(handler_file=os.path.realpath(__file__))
+            self.assertTrue(os.path.isfile(path))
+            os.remove(path)
 
     def test_verify_downloaded_manylinux_wheel(self):
         z = Zappa(runtime="python3.10")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -239,11 +239,11 @@ class TestZappa(unittest.TestCase):
             
     def test_get_manylinux_python313(self):
         z = Zappa(runtime="python3.13")
-        self.assertIsNotNone(z.get_cached_manylinux_wheel("psycopg-binary", "3.1.17"))
+        self.assertIsNotNone(z.get_cached_manylinux_wheel("psycopg-binary", "3.2.5"))
         self.assertIsNone(z.get_cached_manylinux_wheel("derp_no_such_thing", "0.0"))
 
         # mock with a known manylinux wheel package so that code for downloading them gets invoked
-        mock_installed_packages = {"psycopg-binary": "3.1.17"}
+        mock_installed_packages = {"psycopg-binary": "3.2.5"}
         with mock.patch(
             "zappa.core.Zappa.get_installed_packages",
             return_value=mock_installed_packages,
@@ -254,7 +254,7 @@ class TestZappa(unittest.TestCase):
             os.remove(path)
 
         # same, but with an ABI3 package
-        mock_installed_packages = {"cryptography": "41.0.7"}
+        mock_installed_packages = {"cryptography": "44.0.2"}
         with mock.patch(
             "zappa.core.Zappa.get_installed_packages",
             return_value=mock_installed_packages,

--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -12,7 +12,7 @@ def running_in_docker() -> bool:
     return running_in_docker_flag
 
 
-SUPPORTED_VERSIONS = [(3, 8), (3, 9), (3, 10), (3, 11), (3, 12)]
+SUPPORTED_VERSIONS = [(3, 8), (3, 9), (3, 10), (3, 11), (3, 12), (3, 13)]
 MINIMUM_SUPPORTED_MINOR_VERSION = 8
 
 if not running_in_docker() and sys.version_info[:2] not in SUPPORTED_VERSIONS:

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -19,7 +19,6 @@ import time
 import uuid
 import zipfile
 from builtins import bytes, int
-from distutils.dir_util import copy_tree
 from io import open
 from pathlib import Path
 from typing import Optional
@@ -687,7 +686,7 @@ class Zappa:
         if egg_links:
             self.copy_editable_packages(egg_links, temp_package_path)
 
-        copy_tree(temp_package_path, temp_project_path, update=True)
+        copytree(temp_package_path, temp_project_path, metadata=False, symlinks=False)
 
         # Then the pre-compiled packages..
         if use_precompiled_packages:

--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -220,6 +220,8 @@ def get_runtime_from_python_version():
             return "python3.11"
         elif sys.version_info[1] == 12:
             return "python3.12"
+        elif sys.version_info[1] == 13:
+            return "python3.13"
         else:
             raise ValueError(f"Python f{'.'.join(str(v) for v in sys.version_info[:2])} is not yet supported.")
 


### PR DESCRIPTION
## **Description**  
This PR adds support for **Python 3.13** in Zappa, enabling deployments on AWS Lambda with the latest Python runtime. 

The following updates have been made:  
- **Updated `SUPPORTED_VERSIONS` in `zappa/__init__.py`** to include Python 3.13.  
- **Added Python 3.13 to `get_runtime_from_python_version()`** in `zappa/utilities.py`.  
- **Updated the GitHub CI pipeline (`.github/workflows/ci.yml`)** to test against Python 3.13.  
- **Modified `setup.py` classifiers** to reflect Python 3.13 support.  
- **Updated `README.md` and issue templates** to mention Python 3.13 compatibility.  
- **Added a test case in `tests/tests.py`** for verifying Python 3.13 runtime compatibility.  


## **Testing**  
This PR was tested by:  
:orange_square:  Running **CI tests** across supported Python versions (**3.8 – 3.13**).  
:green_square:   Deploying a **test Zappa application** with Python 3.13 to AWS Lambda.  
:green_square: : Running **unit tests** to verify manylinux wheel compatibility with Python 3.13.  

## **GitHub Issue Reference**  
Closes https://github.com/zappa/Zappa/issues/1363
