### PR TITLE
Lambda invocation qualifier and client-context option (#1368)

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,12 @@ For instance, it can come in handy if you want to create your first `superuser` 
 
     $ zappa invoke staging "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('username', 'email', 'password')" --raw
 
+If you need to invoke a specific version of your function, you can use the --qualifier option to specify it.
+
+    $ zappa invoke production my_app.my_function --qualifier 123
+
+[Function aliases](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html) are also supported as qualifiers.
+
 ### Django Management Commands
 
 As a convenience, Zappa can also invoke remote Django 'manage.py' commands with the `manage` command. For instance, to perform the basic Django status check:
@@ -462,6 +468,11 @@ Obviously, this only works for Django projects which have their settings properl
 For commands which have their own arguments, you can also pass the command in as a string, like so:
 
     $ zappa manage production "shell --version"
+
+As with `invoke`, a qualifier can be added to specify the version of your function that's used to execute the command.
+This can be particularly important when running certain commands such as `migrate` directly after a new deployment:
+
+    $ zappa manage production migrate admin --qualifier 123
 
 Commands which require direct user input, such as `createsuperuser`, should be [replaced by commands](http://stackoverflow.com/a/26091252) which use `zappa invoke <env> --raw`.
 

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -294,6 +294,18 @@ class ZappaCLI:
             help=("When invoking remotely, invoke this python as a string," " not as a modular path."),
         )
         invoke_parser.add_argument("--no-color", action="store_true", help=("Don't color the output"))
+        invoke_parser.add_argument(
+            "--client-context",
+            help=(
+                "The ClientContext to send to the Lambda function. Must be valid JSON."
+            ),
+        )
+        invoke_parser.add_argument(
+            "--qualifier",
+            help=(
+                "The qualifier (version or alias) of the lambda version to invoke. $LATEST if omitted."
+            ),
+        )
         invoke_parser.add_argument("command_rest")
 
         ##
@@ -304,6 +316,19 @@ class ZappaCLI:
         manage_parser.add_argument("--all", action="store_true", help=all_help)
         manage_parser.add_argument("command_rest", nargs="+", help=rest_help)
         manage_parser.add_argument("--no-color", action="store_true", help=("Don't color the output"))
+        manage_parser.add_argument(
+            "--client-context",
+            help=(
+                "The ClientContext to send to the Lambda function. Must be valid JSON."
+            ),
+        )
+        manage_parser.add_argument(
+            "--qualifier",
+            help=(
+                "The qualifier (version or alias) of the lambda version to execute the command on. $LATEST if omitted."
+            ),
+        )
+
         # This is explicitly added here because this is the only subcommand that doesn't inherit from env_parser
         # https://github.com/Miserlou/Zappa/issues/1002
         manage_parser.add_argument("-s", "--settings_file", help="The path to a Zappa settings file.")
@@ -587,6 +612,8 @@ class ZappaCLI:
                 self.vargs["command_rest"],
                 raw_python=self.vargs["raw"],
                 no_color=self.vargs["no_color"],
+                client_context=self.vargs["client_context"],
+                qualifier=self.vargs["qualifier"],
             )
         elif command == "manage":  # pragma: no cover
             if not self.vargs.get("command_rest"):
@@ -608,6 +635,8 @@ class ZappaCLI:
                 command,
                 command="manage",
                 no_color=self.vargs["no_color"],
+                client_context=self.vargs["client_context"],
+                qualifier=self.vargs["qualifier"],
             )
 
         elif command == "tail":  # pragma: no cover
@@ -1361,7 +1390,7 @@ class ZappaCLI:
             removed_arns = self.zappa.remove_async_sns_topic(self.lambda_name)
             click.echo("SNS Topic removed: %s" % ", ".join(removed_arns))
 
-    def invoke(self, function_name, raw_python=False, command=None, no_color=False):
+    def invoke(self, function_name, raw_python=False, command=None, no_color=False, client_context=None, qualifier=None):
         """
         Invoke a remote function.
         """
@@ -1375,6 +1404,11 @@ class ZappaCLI:
             command = {"raw_command": function_name}
         else:
             command = {key: function_name}
+        client_context = (
+            base64.b64encode(client_context.encode("utf-8")).decode("utf-8")
+            if client_context
+            else None
+        )
 
         # Can't use hjson
         import json as json
@@ -1383,6 +1417,8 @@ class ZappaCLI:
             self.lambda_name,
             json.dumps(command),
             invocation_type="RequestResponse",
+            client_context=client_context,
+            qualifier=qualifier,
         )
 
         print(self.format_lambda_response(response, not no_color))

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1347,12 +1347,18 @@ class Zappa:
         Directly invoke a named Lambda function with a payload.
         Returns the response.
         """
-        return self.lambda_client.invoke(
-            FunctionName=function_name,
-            InvocationType=invocation_type,
-            LogType=log_type,
-            Payload=payload,
-        )
+        invoke_kwargs = {
+            "FunctionName": function_name,
+            "InvocationType": invocation_type,
+            "LogType": log_type,
+            "Payload": payload,
+        }
+        if client_context:
+            invoke_kwargs["ClientContext"] = client_context
+        if qualifier:
+            invoke_kwargs["Qualifier"] = qualifier
+
+        return self.lambda_client.invoke(**invoke_kwargs)
 
     def rollback_lambda_function_version(self, function_name, versions_back=1, publish=True):
         """


### PR DESCRIPTION
## Description
The CLI `invoke` and `manage` commands now have a --qualifier option that allows invoking a specific Lambda function version or alias.

The --client-context option was also added to allow sending a ClientContext to the Lambda function.

## GitHub Issues
#1368 

