### PR TITLE
Fix/#1380 infinite redirects

### DIFF
--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -585,7 +585,7 @@ class TestZappa(unittest.TestCase):
         event = {
             "version": "2.0",
             "routeKey": "$default",
-            "rawPath": "/",
+            "rawPath": "/return/request/url",
             "rawQueryString": "",
             "headers": {
                 "host": "1234567890.execute-api.us-east-1.amazonaws.com",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1196,7 +1196,7 @@ class TestZappa(unittest.TestCase):
         event = {
             "version": "2.0",
             "routeKey": "ANY /{proxy+}",
-            "rawPath": "/",
+            "rawPath": "/api/",
             "rawQueryString": "",
             "headers": {
                 "accept": "*/*",
@@ -1220,7 +1220,7 @@ class TestZappa(unittest.TestCase):
                 "domainPrefix": "qw8klxioji",
                 "http": {
                     "method": "GET",
-                    "path": "/",
+                    "path": "/api",
                     "protocol": "HTTP/1.1",
                     "sourceIp": "50.191.225.98",
                     "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36",
@@ -1236,6 +1236,8 @@ class TestZappa(unittest.TestCase):
         }
         environ = create_wsgi_request(event)
         self.assertTrue(environ)
+        self.assertEqual(environ["PATH_INFO"], "/api/")
+        self.assertEqual(environ["QUERY_STRING"], "")
 
     def test_wsgi_from_v2_event_with_lambda_authorizer(self):
         principal_id = "user|a1b2c3d4"

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -173,7 +173,7 @@ def process_lambda_payload_v2(event_info):
     headers = event_info["headers"]
     if event_info.get("cookies"):
         headers["cookie"] = "; ".join(event_info["cookies"])
-    path = unquote(event_info["requestContext"]["http"]["path"])
+    path = unquote(event_info["rawPath"])
     query = event_info.get("queryStringParameters", {})
     query_string = urlencode(query) if query else ""
     # Systems calling the Lambda (other than API Gateway) may not provide the field requestContext


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/zappa/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of: **Python 3.8**, **Python 3.9**, **Python 3.10**, **Python 3.11**, **Python 3.12**, and **Python 3.13**?

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description

<!-- Please describe the changes included in this PR -->
- Changes to obtain the path when deploying Lambda Function URLs or API Gateway v2

## GitHub Issues

<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

- https://github.com/zappa/Zappa/issues/1380
