### PR TITLE
Fix API Gateway v2 double path prefix issue

### DIFF
--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -126,8 +126,8 @@ def create_wsgi_request(
         environ["SCRIPT_NAME"] = script_name
         path_info = environ["PATH_INFO"]
 
-        if script_name in path_info:
-            environ["PATH_INFO"].replace(script_name, "")
+        if path_info.startswith(script_name):
+            environ["PATH_INFO"] = path_info[len(script_name):]
 
     if remote_user:
         environ["REMOTE_USER"] = remote_user


### PR DESCRIPTION
## Problem
API Gateway v2 events include the stage in `rawPath`, causing double path prefix in WSGI routing. Requests to `{gateway_url}/{stage}/endpoint` result in routes like `/stage/stage/endpoint` instead of `/stage/endpoint`.

## Solution
Replace flawed `replace()` logic with proper `startswith()` check to correctly strip `script_name` from `PATH_INFO` when present.

## Changes
- Fix path handling in `create_wsgi_request()` function
- Use `startswith()` instead of `in` check
- Properly assign the modified path instead of using `replace()`

## Testing
- Verified fix resolves double prefix issue
- Confirmed backward compatibility with existing functionality
- Tested various edge cases (no stage, different stages, etc.)

Fixes #1389