### PR TITLE
:sparkles: API Gateway v2 (HTTP API) Configuration Support

### DIFF
--- a/test_settings.json
+++ b/test_settings.json
@@ -140,6 +140,10 @@
         "extends": "ttt888",
         "function_url_enabled": true
      },
+    "apigateway_v2": {
+        "extends": "ttt888",
+        "apigateway_version": "v2"
+     },
     "addtextmimetypes": {
        "s3_bucket": "lmbda",
        "app_function": "tests.test_app.hello_world",

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -700,6 +700,7 @@ class ZappaCLI:
             cors_options=self.cors,
             description=self.apigateway_description,
             endpoint_configuration=self.endpoint_configuration,
+            apigateway_version=self.apigateway_version,
         )
 
         if not output:
@@ -874,6 +875,7 @@ class ZappaCLI:
                 cors_options=self.cors,
                 description=self.apigateway_description,
                 endpoint_configuration=self.endpoint_configuration,
+                apigateway_version=self.apigateway_version,
             )
 
             self.zappa.update_stack(
@@ -1092,6 +1094,7 @@ class ZappaCLI:
                 cors_options=self.cors,
                 description=self.apigateway_description,
                 endpoint_configuration=self.endpoint_configuration,
+                apigateway_version=self.apigateway_version,
             )
             self.zappa.update_stack(
                 self.lambda_name,
@@ -1898,7 +1901,7 @@ class ZappaCLI:
             django_settings = django_settings.replace("'", "")
             django_settings = django_settings.replace('"', "")
         else:
-            matches = None
+            matches = []
             if has_flask:
                 click.echo("It looks like this is a " + click.style("Flask", bold=True) + " application.")
                 matches = detect_flask_apps()
@@ -2336,6 +2339,7 @@ class ZappaCLI:
         if self.use_apigateway:
             self.use_apigateway = self.stage_config.get("apigateway_enabled", True)
         self.apigateway_description = self.stage_config.get("apigateway_description", None)
+        self.apigateway_version = self.stage_config.get("apigateway_version", "v1")
 
         self.lambda_handler = self.stage_config.get("lambda_handler", "handler.lambda_handler")
         # DEPRECATED. https://github.com/Miserlou/Zappa/issues/456

--- a/zappa/policies/assume_policy.json
+++ b/zappa/policies/assume_policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "apigateway.amazonaws.com",
+          "lambda.amazonaws.com",
+          "events.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/zappa/policies/attach_policy.json
+++ b/zappa/policies/attach_policy.json
@@ -1,0 +1,87 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:*"
+            ],
+            "Resource": "arn:aws:logs:*:*:*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "lambda:InvokeFunction"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "xray:PutTraceSegments",
+                "xray:PutTelemetryRecords"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AttachNetworkInterface",
+                "ec2:CreateNetworkInterface",
+                "ec2:DeleteNetworkInterface",
+                "ec2:DescribeInstances",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DetachNetworkInterface",
+                "ec2:ModifyNetworkInterfaceAttribute",
+                "ec2:ResetNetworkInterfaceAttribute"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:*"
+            ],
+            "Resource": "arn:aws:s3:::*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kinesis:*"
+            ],
+            "Resource": "arn:aws:kinesis:*:*:*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "sns:*"
+            ],
+            "Resource": "arn:aws:sns:*:*:*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "sqs:*"
+            ],
+            "Resource": "arn:aws:sqs:*:*:*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:*"
+            ],
+            "Resource": "arn:aws:dynamodb:*:*:*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:*"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -68,7 +68,7 @@ def create_wsgi_request(
     headers = titlecase_keys(headers)
 
     if base_path:
-        script_name = "/" + base_path
+        script_name = f"/{base_path}"
 
         if path.startswith(script_name):
             path = path[len(script_name) :]


### PR DESCRIPTION
## Description

:sparkles: API Gateway v2 (HTTP API) Configuration Support
  - Added new setting "apigateway_version" accepting values "v1" (default) or "v2"
  - zappa/core.py:
    - Added DEFAULT_APIGATEWAY_VERSION = "v1" constant
    - Implemented create_api_gateway_v2_routes() method to create HTTP API (v2) using troposphere.apigatewayv2
    - Updated create_api_gateway_routes() to route to v2 method when apigateway_version == "v2"
    - Added type annotations to both API Gateway methods
    - Created v2 resources: Api, Integration, Route, Stage, Lambda Permission
  - zappa/cli.py:
    - Added self.apigateway_version attribute loaded from stage config
    - Passed apigateway_version parameter to all create_stack_template() calls
    - Fixed mypy error: changed matches = None to matches = []

:wrench: Policy Files Refactoring
  - zappa/policies/ (new directory):
    - Created assume_policy.json - IAM assume role policy
    - Created attach_policy.json - IAM attach policy
    - Moved policy definitions from inline code to external JSON files

## GitHub Issues

https://github.com/zappa/Zappa/issues/851
