### PR TITLE
aws lambda now requires additional permission for function url: Invok…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1343,7 +1343,7 @@ the `profile_name` setting, which will correspond to a profile in your AWS crede
 
 The default IAM policy created by Zappa for executing the Lambda is very permissive.
 It grants access to all actions for
-all resources for types CloudWatch, S3, Kinesis, SNS, SQS, DynamoDB, and Route53; lambda:InvokeFunction
+all resources for types CloudWatch, S3, Kinesis, SNS, SQS, DynamoDB, and Route53; lambda:InvokeFunction and lambda:InvokeFunctionUrl
 for all Lambda resources; Put to all X-Ray resources; and all Network Interface operations to all EC2
 resources. While this allows most Lambdas to work correctly with no extra permissions, it is
 generally not an acceptable set of permissions for most continuous integration pipelines or

--- a/example/policy/deploy.json
+++ b/example/policy/deploy.json
@@ -37,6 +37,7 @@
                 "lambda:GetFunctionConfiguration",
                 "lambda:GetPolicy",
                 "lambda:InvokeFunction",
+                "lambda:InvokeFunctionUrl",
                 "lambda:ListVersionsByFunction",
                 "lambda:RemovePermission",
                 "lambda:UpdateFunctionCode",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2839,13 +2839,23 @@ class TestZappa(unittest.TestCase):
             },
         )
 
-        boto_mock.client().add_permission.assert_called_with(
-            FunctionName=function_name,
-            StatementId="FunctionURLAllowPublicAccess",
-            Action="lambda:InvokeFunctionUrl",
-            Principal="*",
-            FunctionUrlAuthType=function_url_config["authorizer"],
-        )
+        expected_permission_calls = [
+            mock.call(
+                FunctionName=function_name,
+                StatementId="FunctionURLAllowPublicAccess",
+                Action="lambda:InvokeFunctionUrl",
+                Principal="*",
+                FunctionUrlAuthType=function_url_config["authorizer"],
+            ),
+            mock.call(
+                FunctionName=function_name,
+                StatementId="FunctionURLAllowPublicAccessInvoke",
+                Action="lambda:InvokeFunction",
+                Principal="*",
+            ),
+        ]
+        boto_mock.client().add_permission.assert_has_calls(expected_permission_calls)
+        self.assertEqual(boto_mock.client().add_permission.call_count, 2)
 
     @mock.patch("botocore.client")
     def test_update_lambda_function_url(self, client):
@@ -2891,7 +2901,9 @@ class TestZappa(unittest.TestCase):
             "ResponseMetadata": {
                 "HTTPStatusCode": 200,
             },
-            "Policy": '{"Version":"2012-10-17","Id":"default","Statement":[{"Sid":"FunctionURLAllowPublicAccess","Effect":"Allow","Principal":"*","Action":"lambda:InvokeFunction","Resource":""}]}',
+            "Policy": '{"Version":"2012-10-17","Id":"default","Statement":['
+            '{"Sid":"FunctionURLAllowPublicAccess","Effect":"Allow","Principal":"*","Action":"lambda:InvokeFunctionUrl","Resource":""},'
+            '{"Sid":"FunctionURLAllowPublicAccessInvoke","Effect":"Allow","Principal":"*","Action":"lambda:InvokeFunction","Resource":""}]}',
         }
 
         zappa_core.update_lambda_function_url(function_name="abc", function_url_config=function_url_config)
@@ -2958,11 +2970,15 @@ class TestZappa(unittest.TestCase):
             "ResponseMetadata": {
                 "HTTPStatusCode": 200,
             },
-            "Policy": '{"Version":"2012-10-17","Id":"default","Statement":[{"Sid":"FunctionURLAllowPublicAccess","Effect":"Allow","Principal":"*","Action":"lambda:InvokeFunction","Resource":""}]}',
+            "Policy": '{"Version":"2012-10-17","Id":"default","Statement":['
+            '{"Sid":"FunctionURLAllowPublicAccess","Effect":"Allow","Principal":"*","Action":"lambda:InvokeFunctionUrl","Resource":""},'
+            '{"Sid":"FunctionURLAllowPublicAccessInvoke","Effect":"Allow","Principal":"*","Action":"lambda:InvokeFunction","Resource":""}]}',
         }
         zappa_core.lambda_client.remove_permission.return_value = {
             "ResponseMetadata": {"HTTPStatusCode": 200},
-            "Policy": '{"Version":"2012-10-17","Id":"default","Statement":[{"Sid":"FunctionURLAllowPublicAccess","Effect":"Allow","Principal":"*","Action":"lambda:InvokeFunction","Resource":"xxxxx"}]}',
+            "Policy": '{"Version":"2012-10-17","Id":"default","Statement":['
+            '{"Sid":"FunctionURLAllowPublicAccess","Effect":"Allow","Principal":"*","Action":"lambda:InvokeFunctionUrl","Resource":"xxxxx"},'
+            '{"Sid":"FunctionURLAllowPublicAccessInvoke","Effect":"Allow","Principal":"*","Action":"lambda:InvokeFunction","Resource":"xxxxx"}]}',
         }
         zappa_core.update_lambda_function_url(function_name="abc", function_url_config=function_url_config)
         boto_mock.client().update_function_url_config.assert_called_with(
@@ -2981,9 +2997,12 @@ class TestZappa(unittest.TestCase):
         boto_mock.client().get_policy.assert_called_with(
             FunctionName=function_arn,
         )
-        boto_mock.client().delete_policy.remove_permission(
-            FunctionName=function_arn, StatementId="FunctionURLAllowPublicAccess"
-        )
+        expected_remove_calls = [
+            mock.call(FunctionName=function_arn, StatementId="FunctionURLAllowPublicAccess"),
+            mock.call(FunctionName=function_arn, StatementId="FunctionURLAllowPublicAccessInvoke"),
+        ]
+        boto_mock.client().remove_permission.assert_has_calls(expected_remove_calls, any_order=True)
+        self.assertEqual(boto_mock.client().remove_permission.call_count, 2)
         boto_mock.client().add_permission.assert_not_called()
         boto_mock.client().create_function_url_config.assert_not_called()
 
@@ -3019,7 +3038,9 @@ class TestZappa(unittest.TestCase):
             "ResponseMetadata": {
                 "HTTPStatusCode": 200,
             },
-            "Policy": '{"Version":"2012-10-17","Id":"default","Statement":[{"Sid":"FunctionURLAllowPublicAccess","Effect":"Allow","Principal":"*","Action":"lambda:InvokeFunction","Resource":""}]}',
+            "Policy": '{"Version":"2012-10-17","Id":"default","Statement":['
+            '{"Sid":"FunctionURLAllowPublicAccess","Effect":"Allow","Principal":"*","Action":"lambda:InvokeFunctionUrl","Resource":""},'
+            '{"Sid":"FunctionURLAllowPublicAccessInvoke","Effect":"Allow","Principal":"*","Action":"lambda:InvokeFunction","Resource":""}]}',
         }
         zappa_core.lambda_client.remove_permission.return_value = {
             "ResponseMetadata": {
@@ -3035,9 +3056,12 @@ class TestZappa(unittest.TestCase):
         boto_mock.client().get_policy.assert_called_with(
             FunctionName=function_arn,
         )
-        boto_mock.client().delete_policy.remove_permission(
-            FunctionName=function_arn, StatementId="FunctionURLAllowPublicAccess"
-        )
+        expected_remove_calls = [
+            mock.call(FunctionName=function_arn, StatementId="FunctionURLAllowPublicAccess"),
+            mock.call(FunctionName=function_arn, StatementId="FunctionURLAllowPublicAccessInvoke"),
+        ]
+        boto_mock.client().remove_permission.assert_has_calls(expected_remove_calls, any_order=True)
+        self.assertEqual(boto_mock.client().remove_permission.call_count, 2)
         boto_mock.client().add_permission.assert_not_called()
         boto_mock.client().create_function_url_config.assert_not_called()
         boto_mock.client().update_function_url_config.assert_not_called()


### PR DESCRIPTION
aws lambda now requires additional permission for function url: InvokeFunction
https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html
<img width="553" height="191" alt="Screenshot 2025-11-03 at 3 48 46 PM" src="https://github.com/user-attachments/assets/c7aaa9f2-bb68-47b9-ac3a-9608a0ed5f38" />
This pull request updates Lambda function URL permissions to ensure both `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction` actions are properly managed. The changes improve security and correctness by handling permissions for public access and IAM authorization, updating policy management logic and corresponding tests.

**Lambda Permission Management Improvements:**

* Added support for both `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction` actions in Lambda policies and permission rules, ensuring correct public access configuration. (`zappa/core.py`, `example/policy/deploy.json`, `README.md`) [[1]](diffhunk://#diff-1272d47d18b49cd4f64c4235c54cebd1d332950e6f54586de07be904310838b2L89-R90) [[2]](diffhunk://#diff-2018a0dfdb762dd569a4f1ed820c2ebb8cb149b357c2824e9609b0ecf7403f95R40) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1346-R1346)
* Refactored permission rule logic to use a list of permission rules (`FUNCTION_URL_PUBLIC_PERMISSION_RULES`) and SIDs, improving maintainability and clarity. (`zappa/core.py`)
* Updated policy listing and deletion logic to handle multiple permission statements for function URLs, not just a single SID. (`zappa/core.py`) [[1]](diffhunk://#diff-1272d47d18b49cd4f64c4235c54cebd1d332950e6f54586de07be904310838b2L1505-R1513) [[2]](diffhunk://#diff-1272d47d18b49cd4f64c4235c54cebd1d332950e6f54586de07be904310838b2R1533-R1547)

**Test Coverage Enhancements:**

* Modified and expanded tests to verify that both permissions are added or removed as appropriate, including checks for call counts and correct arguments. (`tests/test_core.py`) [[1]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058L2842-R2858) [[2]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058L2894-R2906) [[3]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058L2961-R2981) [[4]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058L2984-R3005) [[5]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058L3022-R3043) [[6]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058L3038-R3064)
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/zappa/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of: **Python 3.8**, **Python 3.9**, **Python 3.10**, **Python 3.11**, **Python 3.12**, and **Python 3.13**?

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description

<!-- Please describe the changes included in this PR -->

## GitHub Issues

<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
