### PR TITLE
:bug: fix settings init with django settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Zappa Changelog
 
+## 0.61.3
+
+* Fix `settings` command generating invalid config for Django projects (#1404)
+  - `django_settings` and `app_function` are mutually exclusive
+  - When `django_settings` is provided via environment variable or CLI, `app_function` is now excluded from generated settings
+  - Added regression test `test_zappacli_settings_django_excludes_app_function`
+
 ## 0.61.2
 
 * Add support for Python 3.14 runtime (#1398)

--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -31,4 +31,4 @@ elif running_in_docker() and sys.version_info.minor < MINIMUM_SUPPORTED_MINOR_VE
     )
     raise RuntimeError(err_msg)
 
-__version__ = "0.61.2"
+__version__ = "0.61.3"

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2202,6 +2202,11 @@ class ZappaCLI:
         # Apply configuration to settings (will override defaults)
         settings[stage].update(config)
 
+        # django_settings and app_function are mutually exclusive
+        # If django_settings is provided, remove app_function from the settings
+        if "django_settings" in settings[stage]:
+            settings[stage].pop("app_function", None)
+
         return settings
 
     def settings(self):


### PR DESCRIPTION
  🐛 Bug Fixes

  - Fix settings command incorrectly including app_function for Django projects
    - django_settings and app_function are mutually exclusive settings
    - When django_settings is provided via environment variable (ZAPPA_DJANGO_SETTINGS) or --config argument, app_function is now excluded from generated settings
    - This resolves the 502 deployment errors for Django projects using the settings command

  ✅ Tests

  - Add regression test test_zappacli_settings_django_excludes_app_function
    - Verifies app_function is excluded when django_settings is set via env var
    - Verifies app_function is excluded when django_settings is set via --config
    - Verifies app_function is still present when django_settings is not set

  🔖 Version

  - Bump version to 0.61.3

  📁 Files Changed

  | File               | Changes                                                |
  |--------------------|--------------------------------------------------------|
  | zappa/cli.py       | +5 (exclude app_function when django_settings present) |
  | tests/test_core.py | +55 (regression test)                                  |
  | zappa/__init__.py  | version bump                                           |
  | CHANGELOG.md       | release notes                                          |


## Related ISSUE(s)

https://github.com/zappa/Zappa/issues/1404