### PR TITLE
Remove special s3 function ARN handling

### DIFF
--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -705,15 +705,7 @@ def get_event_source(
     if not event_source_class:
         raise ValueError("Unknown event source: {0}".format(arn))
 
-    # Handle S3 special case for function ARN
-    if svc == "s3":
-        split_arn = lambda_arn.split(":")
-        arn_front = ":".join(split_arn[:-1])
-        arn_back = split_arn[-1]
-        function_arn = ":".join([arn_back, target_function])
-        lambda_arn = arn_front
-    else:
-        function_arn = lambda_arn
+    function_arn = lambda_arn
 
     event_source_obj = event_source_class(boto_session, event_source)
 


### PR DESCRIPTION
## Description

See error in the linked issue. It looks like [the fix from this old linked PR](https://github.com/Miserlou/Zappa/pull/680/changes) was reverted [here](https://github.com/zappa/Zappa/commit/c3c6e3b15536134ca27b35c9bd9ea7cc5a112514), but after kappa 0.6.0 was removed last year in the 0.61 release, it seems a regression was introduced and this change also needed to be made again. I confirmed this by trying to deploy the same repo using zappa 0.60.x and the error mentioned in the issue when 0.61.x is used did not happen.

This change has been tested with with the following config and the deployment works:

```
{
  "production": {
    "project_name": "contact-loader",
    "runtime": "python3.13",
    "apigateway_enabled": false,
    "events": [
      {
        "function": "main.lambda_handler",
        "event_source": {
          "arn": "arn:aws:s3:::<redacted>",
          "events": [
            "s3:ObjectCreated:*"
          ],
          "key_filters": [
            {
              "type": "prefix",
              "value": "contact-lists/"
            }
          ]
        }
      }
    ]
  }
}
```

## GitHub Issues

https://github.com/zappa/Zappa/issues/1413
