### PR TITLE
🐛 Fix API Gateway v2 stage handling for custom domains

### DIFF
--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -731,7 +731,7 @@ class TestZappa(unittest.TestCase):
             "https://api.example.com/return/request/url",
         )
 
-    def test_v2_custom_domain_redirect_URL_does_not_duplicate_stage(self):
+    def test_v2_custom_domain_redirect_url_does_not_duplicate_stage(self):
         """
         Verifies WSGI environ values when using a custom domain with API Gateway V2.
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -689,3 +689,82 @@ class TestZappa(unittest.TestCase):
         self.assertIn("SCRIPT_NAME='/dev'", response["body"])
         self.assertIn("PATH_INFO='/debug/wsgi/environ'", response["body"])  # FIXED: stage stripped
         self.assertIn("/dev/debug/wsgi/environ", response["body"])  # Correct single prefix!
+
+    def test_v2_custom_domain_no_double_stage_redirect(self):
+        """
+        Reproduces double stage redirect when using custom domain with API Gateway V2.
+
+        API Gateway V2 always includes the stage in rawPath, even when the request
+        arrives via a custom domain. For direct access (amazonaws.com), SCRIPT_NAME
+        should be set to the stage. For custom domains, SCRIPT_NAME should be empty
+        and the stage should be stripped from PATH_INFO so the framework generates
+        clean URLs without the stage prefix.
+        """
+        lh = LambdaHandler("tests.test_wsgi_script_name_settings")
+
+        # Simulate API Gateway V2 event arriving via custom domain
+        # rawPath INCLUDES the stage prefix (API Gateway V2 always adds it)
+        event = {
+            "version": "2.0",
+            "routeKey": "$default",
+            "rawPath": "/dev/return/request/url",  # Stage prefix IS in rawPath
+            "rawQueryString": "",
+            "headers": {
+                "host": "api.example.com",  # Custom domain, NOT amazonaws.com
+            },
+            "requestContext": {
+                "http": {
+                    "method": "GET",
+                    "path": "/dev/return/request/url",
+                },
+                "stage": "dev",
+            },
+            "isBase64Encoded": False,
+            "body": "",
+        }
+        response = lh.handler(event, None)
+
+        self.assertEqual(response["statusCode"], 200)
+        # The URL should NOT contain the stage prefix when accessed via custom domain
+        self.assertEqual(
+            response["body"],
+            "https://api.example.com/return/request/url",
+        )
+
+    def test_v2_custom_domain_redirect_URL_does_not_duplicate_stage(self):
+        """
+        Verifies WSGI environ values when using a custom domain with API Gateway V2.
+
+        SCRIPT_NAME should be empty and PATH_INFO should have the stage stripped,
+        so that Django/Flask generates URLs without the stage prefix.
+        """
+        lh = LambdaHandler("tests.test_wsgi_script_name_settings")
+
+        event = {
+            "version": "2.0",
+            "routeKey": "$default",
+            "rawPath": "/dev/debug/wsgi/environ",  # Stage prefix IS in rawPath
+            "rawQueryString": "",
+            "headers": {
+                "host": "api.example.com",  # Custom domain
+            },
+            "requestContext": {
+                "http": {
+                    "method": "GET",
+                    "path": "/dev/debug/wsgi/environ",
+                },
+                "stage": "dev",
+            },
+            "isBase64Encoded": False,
+            "body": "",
+        }
+        response = lh.handler(event, None)
+
+        self.assertEqual(response["statusCode"], 200)
+        # SCRIPT_NAME should be empty (no stage prefix for custom domains)
+        self.assertIn("SCRIPT_NAME=''", response["body"])
+        # PATH_INFO should have the stage stripped
+        self.assertIn("PATH_INFO='/debug/wsgi/environ'", response["body"])
+        # The full URL should NOT contain /dev/ prefix
+        self.assertNotIn("/dev/debug/wsgi/environ", response["body"])
+

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -835,15 +835,30 @@ class LambdaHandler:
                 request_context = event.get("requestContext", {})
                 stage = request_context.get("stage")
 
-                # For API Gateway v2, the stage is included in rawPath and we need to
-                # set script_name so it can be stripped from PATH_INFO
-                # For Function URLs (no stage), leave script_name empty
+                # API Gateway v2 always includes the stage prefix in rawPath,
+                # regardless of whether the request arrives via direct API Gateway URL
+                # or via a custom domain.
+                #
+                # For direct access (amazonaws.com host), we set SCRIPT_NAME to the
+                # stage so the framework generates URLs with the stage prefix.
+                # create_wsgi_request will also strip the stage from PATH_INFO.
+                #
+                # For custom domains, SCRIPT_NAME must remain empty so the framework
+                # generates URLs without the stage prefix (the custom domain's API
+                # Mapping already resolves the stage). But we still need to strip
+                # the stage from PATH_INFO ourselves, since create_wsgi_request
+                # only strips when script_name is set.
+                #
+                # For Function URLs (no stage), no special handling is needed.
+                script_name = ""
+                is_custom_domain = False
                 if stage:
-                    # API Gateway v2 with named stage - rawPath includes the stage
-                    script_name = f"/{stage}"
-                else:
-                    # Function URL - no stage
-                    script_name = ""
+                    headers = event.get("headers", {})
+                    host = headers.get("host", "")
+                    if "amazonaws.com" in host:
+                        script_name = f"/{stage}"
+                    else:
+                        is_custom_domain = True
 
                 # ASGI path
                 if self.app_type == "asgi":
@@ -852,6 +867,14 @@ class LambdaHandler:
                 time_start = datetime.datetime.now()
 
                 environ = self._create_lambda_wsgi_environ(event, context, script_name, settings)
+
+                # For custom domains, strip the stage prefix from PATH_INFO
+                # since rawPath includes it but SCRIPT_NAME is empty
+                if is_custom_domain:
+                    stage_prefix = f"/{stage}"
+                    path_info = environ.get("PATH_INFO", "")
+                    if path_info.startswith(stage_prefix):
+                        environ["PATH_INFO"] = path_info[len(stage_prefix):] or "/"
 
                 # Execute the application
                 with Response.from_app(self.wsgi_app, environ) as response:


### PR DESCRIPTION
## Description

Fix double stage redirect when using API Gateway V2 with a custom domain.

**Problem:** API Gateway V2 always includes the stage name in `rawPath`, even when the request arrives via a custom domain (e.g., `api.example.com`). The previous code always set `SCRIPT_NAME=/{stage}` whenever `requestContext.stage` existed, causing Django/Flask to generate redirect URLs with the stage prefix (e.g., `/dev/admin/`). Since the custom domain's API Mapping already resolves to the correct stage, this resulted in a doubled path like `/dev/dev/admin/`.

**Root cause:** The v1 handler already handled this correctly by checking if the host contains `amazonaws.com` before adding the stage to `SCRIPT_NAME`. The v2 handler was missing this distinction.

**Fix:** Two changes in the v2 event handler (`handler.py`):

1. **Host-based detection:** Only set `SCRIPT_NAME=/{stage}` when the host is `amazonaws.com` (direct API Gateway access). For custom domains, `SCRIPT_NAME` remains empty — consistent with how the v1 handler works.

2. **Manual PATH_INFO stripping:** For custom domain requests, manually strip the stage prefix from `PATH_INFO` after `create_wsgi_request` returns. This is necessary because `create_wsgi_request` only strips the stage when `script_name` is set, but API Gateway V2 always includes the stage in `rawPath` regardless of access method.

| Scenario | `SCRIPT_NAME` | Stage stripped from `PATH_INFO` |
|---|---|---|
| Direct API Gateway (amazonaws.com) | `/{stage}` | By `create_wsgi_request` |
| Custom domain | `""` (empty) | Manually in handler |

**Tests:** Added two new test cases covering the custom domain scenario with realistic API Gateway V2 event payloads. All 26 handler tests pass.

## GitHub Issues

Fixes https://github.com/zappa/Zappa/issues/1409
