### PR TITLE
:bug: Fix rollback for slim_handler by using versioned archive paths

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -3105,9 +3105,9 @@ class ZappaCLI:
 
         # If slim handler, path to project zip
         if self.stage_config.get("slim_handler", False):
-            settings_s += "ARCHIVE_PATH='s3://{0!s}/{1!s}_{2!s}_current_project.tar.gz'\n".format(
-                self.s3_bucket_name, self.api_stage, self.project_name
-            )
+            # Use the versioned archive name so rollback references the correct archive
+            archive_filename = os.path.basename(self.zip_path)
+            settings_s += "ARCHIVE_PATH='s3://{0!s}/{1!s}'\n".format(self.s3_bucket_name, archive_filename)
 
             # since includes are for slim handler add the setting here by joining arbitrary list from zappa_settings file
             # and tell the handler we are the slim_handler


### PR DESCRIPTION
## Summary

Fixes #1383

- `ARCHIVE_PATH` was hardcoded to `{stage}_{project}_current_project.tar.gz`, a fixed S3 key overwritten on every deploy
- On rollback, the old handler zip still pointed to this "current" archive, loading the latest app code instead of the version-matched code
- Now embeds the timestamped archive filename (e.g., `myapp-1709876543.tar.gz`) in `ARCHIVE_PATH` — each Lambda version references its own immutable archive on S3
- The `_current_project.tar.gz` copy is still created for backwards compatibility with existing deployments

## How it works

Before: Every handler zip contained `ARCHIVE_PATH='s3://bucket/stage_app_current_project.tar.gz'`
After: Each handler zip contains `ARCHIVE_PATH='s3://bucket/myapp-1709876543.tar.gz'` (unique per deploy)

On rollback, Lambda restores the old handler zip which now correctly references its own timestamped archive.

## Test plan

- [x] Full test suite passes (271 tests, 2 pre-existing websocket flakes)
- [x] Verified `get_zappa_settings_string()` generates versioned path from `self.zip_path`
- [ ] Manual testing: deploy with `slim_handler=True`, update, then rollback to verify correct version loads