### PR TITLE
:bug: Update existing event sources instead of silently skipping

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -3423,6 +3423,8 @@ class Zappa:
                     logger.info(f"Created {svc} event schedule for {function}!")
                 elif rule_response == "failed":
                     logger.error(f"Problem creating {svc} event schedule for {function}!")
+                elif rule_response == "updated":
+                    logger.info(f"Updated {svc} event schedule for {function}.")
                 elif rule_response == "exists":
                     logger.warning(f"{svc} event schedule for {function} already exists - Nothing to do here.")
                 elif rule_response == "dryrun":

--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -744,13 +744,13 @@ def add_event_source(
     Given an event_source dictionary, create the object and add the event source.
     """
     event_source_obj, function_arn = get_event_source(event_source, lambda_arn, target_function, boto_session, dry=False)
-    # TODO: Detect changes in config and refine exists algorithm
     if not dry:
         if not event_source_obj.status(function_arn):
             event_source_obj.add(function_arn)
             return "successful" if event_source_obj.status(function_arn) else "failed"
         else:
-            return "exists"
+            event_source_obj.update(function_arn)
+            return "updated"
 
     return "dryrun"
 


### PR DESCRIPTION
## Summary

Addresses #1421

- `add_event_source()` returned "exists" without updating when an event source was already present
- For SNS subscriptions, this meant changed filter policies were silently skipped on `zappa update`
- Now calls `update()` on existing event sources to apply config changes (e.g., updated SNS filter policies), returning "updated" status
- **Note:** AWS SNS only allows one subscription per (TopicArn, Protocol, Endpoint), so two events with the same topic and Lambda still share one subscription. This change ensures filter policy updates are applied on re-deploy.

## Test plan

- [x] Full test suite passes (271 tests)
- [ ] Manual testing: deploy with SNS filter policy, change filter, update, verify new filter applied