### PR TITLE
:memo: Add Quick Reference section and streamline README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 
 
 - [About](#about)
+- [Quick Reference](#quick-reference)
+  - [Minimal Configs](#minimal-configs)
+  - [CLI Commands](#cli-commands)
+  - [Limitations and Constraints](#limitations-and-constraints)
 - [Installation and Configuration](#installation-and-configuration)
   - [Running the Initial Setup / Settings](#running-the-initial-setup--settings)
   - [Alternative: Generating Settings via CLI](#alternative-generating-settings-via-cli)
@@ -105,11 +109,7 @@
   - [Lambda Test Console Usage](#lambda-test-console-usage)
     - [`raw_command`](#raw_command)
     - [`manage`](#manage)
-- [Zappa Guides](#zappa-guides)
-- [Zappa in the Press](#zappa-in-the-press)
-- [Sites Using Zappa](#sites-using-zappa)
-- [Related Projects](#related-projects)
-- [Hacks](#hacks)
+- [Community](#community)
 - [Contributing](#contributing)
     - [Using a Local Repo](#using-a-local-repo)
 
@@ -124,7 +124,7 @@
   <i>In a hurry? Click to see <a href="https://htmlpreview.github.io/?https://raw.githubusercontent.com/Miserlou/Talks/master/serverless-sf/big.quickstart.html">(now slightly out-dated) slides from Serverless SF</a>!</i>
 </p>
 
-**Zappa** makes it super easy to build and deploy server-less, event-driven Python applications (including, but not limited to, WSGI and ASGI web apps) on AWS Lambda + API Gateway. Think of it as "serverless" web hosting for your Python apps. That means **infinite scaling**, **zero downtime**, **zero maintenance** - and at a fraction of the cost of your current deployments!
+**Zappa** builds and deploys server-less, event-driven Python applications (including, but not limited to, WSGI and ASGI web apps) on AWS Lambda + API Gateway. Think of it as "serverless" web hosting for your Python apps. That means **infinite scaling**, **zero downtime**, **zero maintenance** - and at a fraction of the cost of your current deployments!
 
 If you've got a Python web app (including Django, Flask, FastAPI, and Starlette apps), it's as easy as:
 
@@ -134,7 +134,7 @@ $ zappa init
 $ zappa deploy
 ```
 
-and now you're server-less! _Wow!_
+and now you're server-less!
 
 > What do you mean "serverless"?
 
@@ -142,19 +142,90 @@ Okay, so there still is a server - but it only has a _40 millisecond_ life cycle
 
 With a traditional HTTP server, the server is online 24/7, processing requests one by one as they come in. If the queue of incoming requests grows too large, some requests will time out. With Zappa, **each request is given its own virtual HTTP "server"** by Amazon API Gateway. AWS handles the horizontal scaling automatically, so no requests ever time out. Each request then calls your application from a memory cache in AWS Lambda and returns the response via Python's WSGI interface. After your app returns, the "server" dies.
 
-Better still, with Zappa you only pay for the milliseconds of server time that you use, so it's many **orders of magnitude cheaper** than VPS/PaaS hosts like Linode or Heroku - and in most cases, it's completely free. Plus, there's no need to worry about load balancing or keeping servers online ever again.
+With Zappa you only pay for the milliseconds of server time that you use, so it's many **orders of magnitude cheaper** than VPS/PaaS hosts like Linode or Heroku - and in most cases, it's completely free. Plus, there's no need to worry about load balancing or keeping servers online ever again.
 
 It's great for deploying serverless microservices with frameworks like Flask and Bottle, and for hosting larger web apps and CMSes with Django. Zappa also supports ASGI frameworks like **FastAPI**, **Starlette**, and **Quart** — deploy async Python apps to Lambda with the same ease. You can use any WSGI or ASGI-compatible app you like! You **probably don't need to change your existing applications** to use it, and you're not locked into using it.
 
-Zappa also lets you build hybrid event-driven applications that can scale to **trillions of events** a year with **no additional effort** on your part! You also get **free SSL certificates**, **global app deployment**, **API access management**, **automatic security policy generation**, **precompiled C-extensions**, **auto keep-warms**, **oversized Lambda packages**, and **many other exclusive features**!
+Zappa also lets you build hybrid event-driven applications with **free SSL certificates**, **global app deployment**, **API access management**, **automatic security policy generation**, **precompiled C-extensions**, **auto keep-warms**, and **oversized Lambda packages**.
 
-And finally, Zappa is **super easy to use**. You can deploy your application with a single command out of the box!
-
-**Awesome!**
 
 <p align="center">
   <img src="http://i.imgur.com/f1PJxCQ.gif" alt="Zappa Demo Gif"/>
 </p>
+
+## Quick Reference
+
+### Minimal Configs
+
+**Flask / Bottle (WSGI):**
+
+```json
+{
+    "dev": {
+        "app_function": "your_module.app",
+        "s3_bucket": "your-s3-bucket"
+    }
+}
+```
+
+**Django:**
+
+```json
+{
+    "dev": {
+        "django_settings": "your_project.settings",
+        "s3_bucket": "your-s3-bucket"
+    }
+}
+```
+
+**FastAPI / Starlette / Quart (ASGI):**
+
+```json
+{
+    "dev": {
+        "app_function": "your_module.app",
+        "app_type": "asgi",
+        "s3_bucket": "your-s3-bucket"
+    }
+}
+```
+
+### CLI Commands
+
+| Command | Description |
+|---|---|
+| `zappa init` | Interactive setup, generates `zappa_settings.json` |
+| `zappa settings --stage <stage>` | Generate settings via CLI (non-interactive) |
+| `zappa deploy <stage>` | First deployment to a stage |
+| `zappa update <stage>` | Push code changes without touching API Gateway routes |
+| `zappa undeploy <stage>` | Remove API Gateway and Lambda function |
+| `zappa rollback <stage> -n <N>` | Roll back N versions |
+| `zappa schedule <stage>` | Register scheduled events and event sources |
+| `zappa unschedule <stage>` | Remove scheduled event rules |
+| `zappa package <stage>` | Build deployment package without deploying |
+| `zappa template <stage>` | Generate API Gateway CloudFormation template |
+| `zappa status <stage>` | Show deployment status and event schedules |
+| `zappa tail <stage>` | Stream CloudWatch logs |
+| `zappa invoke <stage> <func>` | Execute a function remotely |
+| `zappa manage <stage> <cmd>` | Run Django management command |
+| `zappa certify` | Set up SSL certificate for custom domain |
+
+### Limitations and Constraints
+
+| Constraint | Detail |
+|---|---|
+| Python versions | 3.9, 3.10, 3.11, 3.12, 3.13, 3.14 |
+| Package size | 50MB zip limit; use [`slim_handler: true`](#large-projects) for larger projects |
+| Lambda timeout | Default 30s, max 900s; [API Gateway hard-limits at 30s](#application-load-balancer-event-source) (use ALB for longer) |
+| Concurrent executions | AWS default 1000; [request increase](#raising-aws-service-limits) via support ticket |
+| Virtual environment | Zappa must be installed in a venv; venv name must differ from project name |
+| Default IAM policy | Overly permissive; [customize for production](#custom-aws-iam-roles-and-policies-for-execution) |
+| Event function naming | Pattern `^[._A-Za-z0-9]{0,63}$` — [no hyphens allowed](#eventbridge-rule-naming) |
+| Async task args | Must be JSON-serializable, [under 256K](#restrictions) |
+| ASGI limitations | [No WebSocket via ASGI](#asgi-limitations), no lifespan protocol, no streaming responses |
+| Static files | Not designed for static assets; [use S3 + CloudFront](#serving-static-files--binary-uploads) |
+| VPC internet access | Lambda in VPC [requires NAT gateway](#running-tasks-in-a-vpc) for internet access |
 
 ## Installation and Configuration
 
@@ -320,9 +391,9 @@ Once your settings are configured, you can package and deploy your application t
     Deploying..
     Your application is now live at: https://7k6anj0k99.execute-api.us-east-1.amazonaws.com/production
 
-And now your app is **live!** How cool is that?!
+And now your app is **live!**
 
-To explain what's going on, when you call `deploy`, Zappa will automatically package up your application and local virtual environment into a Lambda-compatible archive, replace any dependencies with versions with wheels compatible with lambda, set up the function handler and necessary WSGI Middleware, upload the archive to S3, create and manage the necessary Amazon IAM policies and roles, register it as a new Lambda function, create a new API Gateway resource, create WSGI-compatible routes for it, link it to the new Lambda function, and finally delete the archive from your S3 bucket. Handy!
+To explain what's going on, when you call `deploy`, Zappa will automatically package up your application and local virtual environment into a Lambda-compatible archive, replace any dependencies with versions with wheels compatible with lambda, set up the function handler and necessary WSGI Middleware, upload the archive to S3, create and manage the necessary Amazon IAM policies and roles, register it as a new Lambda function, create a new API Gateway resource, create WSGI-compatible routes for it, link it to the new Lambda function, and finally delete the archive from your S3 bucket.
 
 Be aware that the default IAM role and policy created for executing Lambda applies a liberal set of permissions.
 These are most likely not appropriate for production deployment of important applications. See the section
@@ -608,7 +679,7 @@ For instance, suppose you have a basic application in a file called "my_app.py",
 
     $ zappa invoke production my_app.my_function
 
-Any remote print statements made and the value the function returned will then be printed to your local console. **Nifty!**
+Any remote print statements made and the value the function returned will then be printed to your local console.
 
 You can also invoke interpretable Python 3.9/3.10/3.11/3.12/3.13/3.14 strings directly by using `--raw`, like so:
 
@@ -1258,7 +1329,7 @@ However, generally Zappa is designed for running your application code, not for 
 
 Your web application framework will likely be able to handle this for you automatically. For Flask, there is [Flask-S3](https://github.com/e-dard/flask-s3), and for Django, there is [Django-Storages](https://django-storages.readthedocs.io/en/latest/).
 
-Similarly, you may want to design your application so that static binary uploads go [directly to S3](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/browser-examples.html#Uploading_a_local_file_using_the_File_API), which then triggers an event response defined in your `events` setting! That's thinking serverlessly!
+Similarly, you may want to design your application so that static binary uploads go [directly to S3](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/browser-examples.html#Uploading_a_local_file_using_the_File_API), which then triggers an event response defined in your `events` setting.
 
 ### Enabling CORS
 
@@ -2121,83 +2192,9 @@ Example:
 }
 ```
 
-## Zappa Guides
+## Community
 
-- [Django-Zappa tutorial (screencast)](https://www.youtube.com/watch?v=plUrbPN0xc8&feature=youtu.be).
-- [Using Django-Zappa, Part 1](https://serverlesscode.com/post/zappa-wsgi-for-python/).
-- [Using Django-Zappa, Part 2: VPCs](https://serverlesscode.com/post/zappa-wsgi-for-python-pt-2/).
-- [Building Serverless Microservices with Zappa and Flask](https://gun.io/blog/serverless-microservices-with-zappa-and-flask/)
-- [Zappa で Hello World するまで (Japanese)](http://qiita.com/satoshi_iwashita/items/505492193317819772c7)
-- [How to Deploy Zappa with CloudFront, RDS and VPC](https://jinwright.net/how-deploy-serverless-wsgi-app-using-zappa/)
-- [Secure 'Serverless' File Uploads with AWS Lambda, S3, and Zappa](http://blog.stratospark.com/secure-serverless-file-uploads-with-aws-lambda-s3-zappa.html)
-- [Deploy a Serverless WSGI App using Zappa, CloudFront, RDS, and VPC](https://docs.google.com/presentation/d/1aYeOMgQl4V_fFgT5VNoycdXtob1v6xVUWlyxoTEiTw0/edit#slide=id.p)
-- [AWS: Deploy Alexa Ask Skills with Flask-Ask and Zappa](https://developer.amazon.com/blogs/post/8e8ad73a-99e9-4c0f-a7b3-60f92287b0bf/New-Alexa-Tutorial-Deploy-Flask-Ask-Skills-to-AWS-Lambda-with-Zappa)
-- [Guide to using Django with Zappa](https://edgarroman.github.io/zappa-django-guide/)
-- [Zappa and LambCI](https://seancoates.com/blogs/zappa-and-lambci/)
-- [Building A Serverless Image Processing SaaS using Zappa](https://medium.com/99serverless/building-a-serverless-image-processing-saas-9ef68b594076)
-- [Serverless Slack Slash Commands with Python and Zappa](https://renzo.lucioni.xyz/serverless-slash-commands-with-python/)
-- [Bringing Tokusatsu to AWS using Python, Flask, Zappa and Contentful](https://www.contentful.com/blog/2018/03/07/bringing-tokusatsu-to-aws-using-python-flask-zappa-and-contentful/)
-- [AWS Summit 2018 Seoul - Zappa와 함께하는 Serverless Microservice](https://www.slideshare.net/YunSeopSong/zappa-serverless-microservice-94410308/)
-- [Book - Building Serverless Python Web Services with Zappa](https://github.com/PacktPublishing/Building-Serverless-Python-Web-Services-with-Zappa)
-- [Vider sa flask dans une lambda](http://free_zed.gitlab.io/articles/2019/11/vider-sa-flask-dans-une-lambda/)[French]
-- _Your guide here?_
-
-## Zappa in the Press
-
-- _[Zappa Serves Python, Minus the Servers](http://www.infoworld.com/article/3031665/application-development/zappa-serves-python-web-apps-minus-the-servers.html)_
-- _[Zappa lyfter serverlösa applikationer med Python](http://computersweden.idg.se/2.2683/1.649895/zappa-lyfter-python)_
-- _[Interview: Rich Jones on Zappa](https://serverlesscode.com/post/rich-jones-interview-django-zappa/)_
-- [Top 10 Python Libraries of 2016](https://tryolabs.com/blog/2016/12/20/top-10-python-libraries-of-2016/)
-
-## Sites Using Zappa
-
-- [Mailchimp Signup Utility](https://github.com/sasha42/Mailchimp-utility) - A microservice for adding people to a mailing list via API.
-- [Zappa Slack Inviter](https://github.com/Miserlou/zappa-slack-inviter) - A tiny, server-less service for inviting new users to your Slack channel.
-- [Serverless Image Host](https://github.com/Miserlou/serverless-imagehost) - A thumbnailing service with Flask, Zappa and Pillow.
-- [Zappa BitTorrent Tracker](https://github.com/Miserlou/zappa-bittorrent-tracker) - An experimental server-less BitTorrent tracker. Work in progress.
-- [JankyGlance](https://github.com/Miserlou/JankyGlance) - A server-less Yahoo! Pipes replacement.
-- [LambdaMailer](https://github.com/tryolabs/lambda-mailer) - A server-less endpoint for processing a contact form.
-- [Voter Registration Microservice](https://topics.arlingtonva.us/2016/11/voter-registration-search-microservice/) - Official backup to to the Virginia Department of Elections portal.
-- [FreePoll Online](https://www.freepoll.online) - A simple and awesome say for groups to make decisions.
-- [PasteOfCode](https://paste.ofcode.org/) - A Zappa-powered paste bin.
-- And many more, including banks, governments, startups, enterprises and schools!
-
-Are you using Zappa? Let us know and we'll list your site here!
-
-## Related Projects
-
-- [Mackenzie](http://github.com/Miserlou/Mackenzie) - AWS Lambda Infection Toolkit
-- [NoDB](https://github.com/Miserlou/NoDB) - A simple, server-less, Pythonic object store based on S3.
-- [zappa-cms](http://github.com/Miserlou/zappa-cms) - A tiny server-less CMS for busy hackers. Work in progress.
-- [zappa-django-utils](https://github.com/Miserlou/zappa-django-utils) - Utility commands to help Django deployments.
-- [flask-ask](https://github.com/johnwheeler/flask-ask) - A framework for building Amazon Alexa applications. Uses Zappa for deployments.
-- [zappa-file-widget](https://github.com/anush0247/zappa-file-widget) - A Django plugin for supporting binary file uploads in Django on Zappa.
-- [zops](https://github.com/bjinwright/zops) - Utilities for teams and continuous integrations using Zappa.
-- [cookiecutter-mobile-backend](https://github.com/narfman0/cookiecutter-mobile-backend/) - A `cookiecutter` Django project with Zappa and S3 uploads support.
-- [zappa-examples](https://github.com/narfman0/zappa-examples/) - Flask, Django, image uploads, and more!
-- [zappa-hug-example](https://github.com/mcrowson/zappa-hug-example) - Example of a Hug application using Zappa.
-- [Zappa Docker Image](https://github.com/danielwhatmuff/zappa) - A Docker image for running Zappa locally, based on Lambda Docker.
-- [zappa-dashing](https://github.com/nikos/zappa-dashing) - Monitor your AWS environment (health/metrics) with Zappa and CloudWatch.
-- [s3env](https://github.com/cameronmaske/s3env) - Manipulate a remote Zappa environment variable key/value JSON object file in an S3 bucket through the CLI.
-- [zappa_resize_image_on_fly](https://github.com/wobeng/zappa_resize_image_on_fly) - Resize images on the fly using Flask, Zappa, Pillow, and OpenCV-python.
-- [zappa-ffmpeg](https://github.com/ubergarm/zappa-ffmpeg) - Run ffmpeg inside a lambda for serverless transformations.
-- [gdrive-lambda](https://github.com/richiverse/gdrive-lambda) - pass json data to a csv file for end users who use Gdrive across the organization.
-- [travis-build-repeat](https://github.com/bcongdon/travis-build-repeat) - Repeat TravisCI builds to avoid stale test results.
-- [wunderskill-alexa-skill](https://github.com/mcrowson/wunderlist-alexa-skill) - An Alexa skill for adding to a Wunderlist.
-- [xrayvision](https://github.com/mathom/xrayvision) - Utilities and wrappers for using AWS X-Ray with Zappa.
-- [terraform-aws-zappa](https://github.com/dpetzold/terraform-aws-zappa) - Terraform modules for creating a VPC, RDS instance, ElastiCache Redis and CloudFront Distribution for use with Zappa.
-- [zappa-sentry](https://github.com/jneves/zappa-sentry) - Integration with Zappa and Sentry
-- [IOpipe](https://github.com/iopipe/iopipe-python#zappa) - Monitor, profile and analyze your Zappa apps.
-
-## Hacks
-
-Zappa goes quite far beyond what Lambda and API Gateway were ever intended to handle. As a result, there are quite a few hacks in here that allow it to work. Some of those include, but aren't limited to..
-
-- Using VTL to map body, headers, method, params and query strings into JSON, and then turning that into valid WSGI.
-- Attaching response codes to response bodies, Base64 encoding the whole thing, using that as a regex to route the response code, decoding the body in VTL, and mapping the response body to that.
-- Packing and _Base58_ encoding multiple cookies into a single cookie because we can only map one kind.
-- Forcing the case permutations of "Set-Cookie" in order to return multiple headers at the same time.
-- Turning cookie-setting 301/302 responses into 200 responses with HTML redirects, because we have no way to set headers on redirects.
+For guides, press coverage, sites using Zappa, related projects, and implementation details, see [Community & Resources](docs/community.md).
 
 ## Contributing
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,79 @@
+# Zappa Community & Resources
+
+## Zappa Guides
+
+- [Django-Zappa tutorial (screencast)](https://www.youtube.com/watch?v=plUrbPN0xc8&feature=youtu.be).
+- [Using Django-Zappa, Part 1](https://serverlesscode.com/post/zappa-wsgi-for-python/).
+- [Using Django-Zappa, Part 2: VPCs](https://serverlesscode.com/post/zappa-wsgi-for-python-pt-2/).
+- [Building Serverless Microservices with Zappa and Flask](https://gun.io/blog/serverless-microservices-with-zappa-and-flask/)
+- [Zappa で Hello World するまで (Japanese)](http://qiita.com/satoshi_iwashita/items/505492193317819772c7)
+- [How to Deploy Zappa with CloudFront, RDS and VPC](https://jinwright.net/how-deploy-serverless-wsgi-app-using-zappa/)
+- [Secure 'Serverless' File Uploads with AWS Lambda, S3, and Zappa](http://blog.stratospark.com/secure-serverless-file-uploads-with-aws-lambda-s3-zappa.html)
+- [Deploy a Serverless WSGI App using Zappa, CloudFront, RDS, and VPC](https://docs.google.com/presentation/d/1aYeOMgQl4V_fFgT5VNoycdXtob1v6xVUWlyxoTEiTw0/edit#slide=id.p)
+- [AWS: Deploy Alexa Ask Skills with Flask-Ask and Zappa](https://developer.amazon.com/blogs/post/8e8ad73a-99e9-4c0f-a7b3-60f92287b0bf/New-Alexa-Tutorial-Deploy-Flask-Ask-Skills-to-AWS-Lambda-with-Zappa)
+- [Guide to using Django with Zappa](https://edgarroman.github.io/zappa-django-guide/)
+- [Zappa and LambCI](https://seancoates.com/blogs/zappa-and-lambci/)
+- [Building A Serverless Image Processing SaaS using Zappa](https://medium.com/99serverless/building-a-serverless-image-processing-saas-9ef68b594076)
+- [Serverless Slack Slash Commands with Python and Zappa](https://renzo.lucioni.xyz/serverless-slash-commands-with-python/)
+- [Bringing Tokusatsu to AWS using Python, Flask, Zappa and Contentful](https://www.contentful.com/blog/2018/03/07/bringing-tokusatsu-to-aws-using-python-flask-zappa-and-contentful/)
+- [AWS Summit 2018 Seoul - Zappa와 함께하는 Serverless Microservice](https://www.slideshare.net/YunSeopSong/zappa-serverless-microservice-94410308/)
+- [Book - Building Serverless Python Web Services with Zappa](https://github.com/PacktPublishing/Building-Serverless-Python-Web-Services-with-Zappa)
+- [Vider sa flask dans une lambda](http://free_zed.gitlab.io/articles/2019/11/vider-sa-flask-dans-une-lambda/)[French]
+- _Your guide here?_
+
+## Zappa in the Press
+
+- _[Zappa Serves Python, Minus the Servers](http://www.infoworld.com/article/3031665/application-development/zappa-serves-python-web-apps-minus-the-servers.html)_
+- _[Zappa lyfter serverlösa applikationer med Python](http://computersweden.idg.se/2.2683/1.649895/zappa-lyfter-python)_
+- _[Interview: Rich Jones on Zappa](https://serverlesscode.com/post/rich-jones-interview-django-zappa/)_
+- [Top 10 Python Libraries of 2016](https://tryolabs.com/blog/2016/12/20/top-10-python-libraries-of-2016/)
+
+## Sites Using Zappa
+
+- [Mailchimp Signup Utility](https://github.com/sasha42/Mailchimp-utility) - A microservice for adding people to a mailing list via API.
+- [Zappa Slack Inviter](https://github.com/Miserlou/zappa-slack-inviter) - A tiny, server-less service for inviting new users to your Slack channel.
+- [Serverless Image Host](https://github.com/Miserlou/serverless-imagehost) - A thumbnailing service with Flask, Zappa and Pillow.
+- [Zappa BitTorrent Tracker](https://github.com/Miserlou/zappa-bittorrent-tracker) - An experimental server-less BitTorrent tracker. Work in progress.
+- [JankyGlance](https://github.com/Miserlou/JankyGlance) - A server-less Yahoo! Pipes replacement.
+- [LambdaMailer](https://github.com/tryolabs/lambda-mailer) - A server-less endpoint for processing a contact form.
+- [Voter Registration Microservice](https://topics.arlingtonva.us/2016/11/voter-registration-search-microservice/) - Official backup to to the Virginia Department of Elections portal.
+- [FreePoll Online](https://www.freepoll.online) - A simple and awesome say for groups to make decisions.
+- [PasteOfCode](https://paste.ofcode.org/) - A Zappa-powered paste bin.
+- And many more, including banks, governments, startups, enterprises and schools!
+
+Are you using Zappa? Let us know and we'll list your site here!
+
+## Related Projects
+
+- [Mackenzie](http://github.com/Miserlou/Mackenzie) - AWS Lambda Infection Toolkit
+- [NoDB](https://github.com/Miserlou/NoDB) - A simple, server-less, Pythonic object store based on S3.
+- [zappa-cms](http://github.com/Miserlou/zappa-cms) - A tiny server-less CMS for busy hackers. Work in progress.
+- [zappa-django-utils](https://github.com/Miserlou/zappa-django-utils) - Utility commands to help Django deployments.
+- [flask-ask](https://github.com/johnwheeler/flask-ask) - A framework for building Amazon Alexa applications. Uses Zappa for deployments.
+- [zappa-file-widget](https://github.com/anush0247/zappa-file-widget) - A Django plugin for supporting binary file uploads in Django on Zappa.
+- [zops](https://github.com/bjinwright/zops) - Utilities for teams and continuous integrations using Zappa.
+- [cookiecutter-mobile-backend](https://github.com/narfman0/cookiecutter-mobile-backend/) - A `cookiecutter` Django project with Zappa and S3 uploads support.
+- [zappa-examples](https://github.com/narfman0/zappa-examples/) - Flask, Django, image uploads, and more!
+- [zappa-hug-example](https://github.com/mcrowson/zappa-hug-example) - Example of a Hug application using Zappa.
+- [Zappa Docker Image](https://github.com/danielwhatmuff/zappa) - A Docker image for running Zappa locally, based on Lambda Docker.
+- [zappa-dashing](https://github.com/nikos/zappa-dashing) - Monitor your AWS environment (health/metrics) with Zappa and CloudWatch.
+- [s3env](https://github.com/cameronmaske/s3env) - Manipulate a remote Zappa environment variable key/value JSON object file in an S3 bucket through the CLI.
+- [zappa_resize_image_on_fly](https://github.com/wobeng/zappa_resize_image_on_fly) - Resize images on the fly using Flask, Zappa, Pillow, and OpenCV-python.
+- [zappa-ffmpeg](https://github.com/ubergarm/zappa-ffmpeg) - Run ffmpeg inside a lambda for serverless transformations.
+- [gdrive-lambda](https://github.com/richiverse/gdrive-lambda) - pass json data to a csv file for end users who use Gdrive across the organization.
+- [travis-build-repeat](https://github.com/bcongdon/travis-build-repeat) - Repeat TravisCI builds to avoid stale test results.
+- [wunderskill-alexa-skill](https://github.com/mcrowson/wunderlist-alexa-skill) - An Alexa skill for adding to a Wunderlist.
+- [xrayvision](https://github.com/mathom/xrayvision) - Utilities and wrappers for using AWS X-Ray with Zappa.
+- [terraform-aws-zappa](https://github.com/dpetzold/terraform-aws-zappa) - Terraform modules for creating a VPC, RDS instance, ElastiCache Redis and CloudFront Distribution for use with Zappa.
+- [zappa-sentry](https://github.com/jneves/zappa-sentry) - Integration with Zappa and Sentry
+- [IOpipe](https://github.com/iopipe/iopipe-python#zappa) - Monitor, profile and analyze your Zappa apps.
+
+## Hacks
+
+Zappa goes quite far beyond what Lambda and API Gateway were ever intended to handle. As a result, there are quite a few hacks in here that allow it to work. Some of those include, but aren't limited to..
+
+- Using VTL to map body, headers, method, params and query strings into JSON, and then turning that into valid WSGI.
+- Attaching response codes to response bodies, Base64 encoding the whole thing, using that as a regex to route the response code, decoding the body in VTL, and mapping the response body to that.
+- Packing and _Base58_ encoding multiple cookies into a single cookie because we can only map one kind.
+- Forcing the case permutations of "Set-Cookie" in order to return multiple headers at the same time.
+- Turning cookie-setting 301/302 responses into 200 responses with HTML redirects, because we have no way to set headers on redirects.


### PR DESCRIPTION
## Summary

- Add **Quick Reference** section after About with minimal configs (Flask/Django/FastAPI), CLI commands table, and consolidated limitations/constraints table with anchor links to detailed sections
- Move community content (guides, press, sites, related projects, hacks) to `docs/community.md` — reduces README noise by ~77 lines
- Trim marketing language ("Wow!", "Nifty!", "How cool is that?!", etc.) — 10 edits removing filler that wastes agent context tokens

## Motivation

Improve README readability for AI coding agents that help users integrate Zappa. Key constraints (50MB package limit, event function naming, ASGI limitations, VPC NAT requirements) were scattered deep in the 2,200-line README — agents would truncate or miss them. The Quick Reference surfaces all critical information in the first ~230 lines.

## Test plan

- [x] `tests/test_docs.py` TOC test passes
- [x] `tests/test_utilities.py` passes
- [ ] Verify Quick Reference anchor links resolve correctly on GitHub
- [ ] Verify `docs/community.md` link works from README