### PR TITLE
:bug: Clarify Docker usage: guard slim_handler and clean up S3 archive on undeploy (#1341)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Zappa Changelog
 
+## Unreleased
+
+* Clarify Docker deployment handling for `slim_handler` (#1341)
+  - `zappa deploy`, `zappa update`, and `zappa save-python-settings-file` now fail fast with a clear error when `--docker-image-uri` is used with a stage that sets `slim_handler` (this combination writes a stale `ARCHIVE_PATH` into `zappa_settings.py` and causes the container handler to load old code from S3).
+  - `zappa undeploy` now removes the `<stage>_<project>_current_project.tar.gz` archive from the configured S3 bucket when `slim_handler` was enabled, so a later redeploy cannot load stale code.
+  - README: documented which `zappa_settings` keys should not be used with Docker deployments.
+
 ## 0.61.4
 
 * Fix manylinux wheel matching to support multiple PEP 600 platform tags (#1411)

--- a/README.md
+++ b/README.md
@@ -426,6 +426,15 @@ Update Example:
 
 Refer to [the blog post](https://ianwhitestone.work/zappa-serverless-docker/) for more details about how to leverage this functionality, and when you may want to.
 
+##### Settings that should NOT be used with Docker deployments
+
+When deploying with `--docker-image-uri`, the Docker image is responsible for bundling your application code and runtime. A few `zappa_settings` keys only make sense for zip-based deployments and will cause problems if left enabled for a Docker deployment:
+
+- `slim_handler`: This option splits the package into a slim handler and a separate project archive uploaded to S3. When enabled, Zappa writes an `ARCHIVE_PATH` into the generated `zappa_settings.py`, which makes the Lambda handler attempt to download the project archive from S3 at cold start and overlay it on your container's code. With a Docker deployment this either loads stale code from a previous zip deploy, or fails entirely if the archive is missing. **Do not set `slim_handler` for Docker deployments.** See [issue #1341](https://github.com/zappa/Zappa/issues/1341).
+- `runtime`: The Python runtime is determined by the Docker image, so this value is ignored for Docker deployments.
+
+Running `zappa deploy`, `zappa update`, or `zappa save-python-settings-file` with a Docker-targeted configuration will now fail fast when any incompatible setting above is detected. Undeploying a stage that previously used `slim_handler` will also remove the leftover `_current_project.tar.gz` archive from the configured S3 bucket.
+
 If you are using a custom Docker image for your Lambda runtime (e.g. if you want to use a newer version of Python that is not yet supported by Lambda out of the box) and you would like to bypass the Python version check, you can set an environment variable to do so:
 
     $ export ZAPPA_RUNNING_IN_DOCKER=True

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
   - [Initial Deployments](#initial-deployments)
   - [Updates](#updates)
     - [Docker Workflows](#docker-workflows)
+      - [Settings that should NOT be used with Docker deployments](#settings-that-should-not-be-used-with-docker-deployments)
   - [Rollback](#rollback)
   - [Scheduling](#scheduling)
     - [Advanced Scheduling](#advanced-scheduling)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3420,6 +3420,69 @@ class TestZappa(unittest.TestCase):
 
         zappa_cli.remove_local_zip()
 
+    def test_docker_deploy_rejects_slim_handler(self):
+        # Issue #1341: slim_handler + Docker produces a stale ARCHIVE_PATH in
+        # the generated zappa_settings.py, so deploy must fail fast.
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = "slim_handler"
+        zappa_cli.load_settings("test_settings.json")
+        with self.assertRaises(ClickException) as exc_ctx:
+            zappa_cli.deploy(docker_image_uri="1234.dkr.ecr.us-east-1.amazonaws.com/repo:latest")
+        self.assertIn("slim_handler", str(exc_ctx.exception.message))
+
+    def test_docker_update_rejects_slim_handler(self):
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = "slim_handler"
+        zappa_cli.load_settings("test_settings.json")
+        with self.assertRaises(ClickException) as exc_ctx:
+            zappa_cli.update(docker_image_uri="1234.dkr.ecr.us-east-1.amazonaws.com/repo:latest")
+        self.assertIn("slim_handler", str(exc_ctx.exception.message))
+
+    def test_save_python_settings_file_rejects_slim_handler(self):
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = "slim_handler"
+        zappa_cli.load_settings("test_settings.json")
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "zappa_settings.py")
+            with self.assertRaises(ClickException) as exc_ctx:
+                zappa_cli.save_python_settings_file(out)
+            self.assertIn("slim_handler", str(exc_ctx.exception.message))
+            self.assertFalse(os.path.exists(out))
+
+    def test_docker_deploy_ok_without_slim_handler(self):
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = "ttt888"
+        zappa_cli.load_settings("test_settings.json")
+        self.assertFalse(zappa_cli.stage_config.get("slim_handler"))
+        zappa_cli._check_docker_settings_conflicts()
+
+    def test_undeploy_removes_slim_handler_archive(self):
+        # Issue #1341: undeploy must clean up the S3 project archive so a
+        # later redeploy does not load stale code.
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = "slim_handler"
+        zappa_cli.load_settings("test_settings.json")
+        zappa_cli.zappa = mock.MagicMock()
+        zappa_cli.use_alb = False
+        zappa_cli.use_apigateway = False
+
+        zappa_cli.undeploy(no_confirm=True)
+
+        expected_key = "{0}_{1}_current_project.tar.gz".format(zappa_cli.api_stage, zappa_cli.project_name)
+        zappa_cli.zappa.remove_from_s3.assert_called_once_with(expected_key, zappa_cli.s3_bucket_name)
+
+    def test_undeploy_skips_archive_cleanup_without_slim_handler(self):
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = "ttt888"
+        zappa_cli.load_settings("test_settings.json")
+        zappa_cli.zappa = mock.MagicMock()
+        zappa_cli.use_alb = False
+        zappa_cli.use_apigateway = False
+
+        zappa_cli.undeploy(no_confirm=True)
+
+        zappa_cli.zappa.remove_from_s3.assert_not_called()
+
     def test_settings_py_generation(self):
         zappa_cli = ZappaCLI()
         zappa_cli.api_stage = "ttt888"

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -192,6 +192,23 @@ class ZappaCLI:
         self._stage_config_overrides = getattr(self, "_stage_config_overrides", {})
         self._stage_config_overrides.setdefault(self.api_stage, {})[key] = val
 
+    # slim_handler writes an ARCHIVE_PATH into zappa_settings.py, which causes
+    # the container handler to overlay stale S3 code on the image code. See #1341.
+    DOCKER_INCOMPATIBLE_SETTINGS = ("slim_handler",)
+
+    def _get_slim_handler_archive_name(self):
+        return "{0!s}_{1!s}_current_project.tar.gz".format(self.api_stage, self.project_name)
+
+    def _check_docker_settings_conflicts(self):
+        conflicts = [key for key in self.DOCKER_INCOMPATIBLE_SETTINGS if self.stage_config.get(key)]
+        if conflicts:
+            raise ClickException(
+                click.style("Invalid Zappa settings for Docker deployment", fg="red", bold=True)
+                + ": the following setting(s) are not compatible with Docker deployments and must be removed or disabled: "
+                + click.style(", ".join(conflicts), bold=True)
+                + ".\nSee the 'Docker Workflows' section of the README for details."
+            )
+
     def handle(self, argv=None):
         """
         Main function.
@@ -722,6 +739,9 @@ class ZappaCLI:
         print("Generating Zappa settings Python file and saving to {}".format(settings_path))
         if not settings_path.endswith("zappa_settings.py"):
             raise ValueError("Settings file must be named zappa_settings.py")
+        # save-python-settings-file is only used for Docker-based deployments,
+        # so surface conflicting settings (e.g. slim_handler) before writing the file.
+        self._check_docker_settings_conflicts()
         zappa_settings_s = self.get_zappa_settings_string()
         with open(settings_path, "w") as f_out:
             f_out.write(zappa_settings_s)
@@ -796,6 +816,9 @@ class ZappaCLI:
         Package your project, upload it to S3, register the Lambda function
         and create the API Gateway routes.
         """
+
+        if docker_image_uri:
+            self._check_docker_settings_conflicts()
 
         if not source_zip or docker_image_uri:
             # Make sure the necessary IAM execution roles are available
@@ -879,7 +902,7 @@ class ZappaCLI:
                     raise ClickException("Unable to upload handler to S3. Quitting.")
 
                 # Copy the project zip to the current project zip
-                current_project_name = "{0!s}_{1!s}_current_project.tar.gz".format(self.api_stage, self.project_name)
+                current_project_name = self._get_slim_handler_archive_name()
                 success = self.zappa.copy_on_s3(
                     src_file_name=self.zip_path,
                     dst_file_name=current_project_name,
@@ -1041,6 +1064,9 @@ class ZappaCLI:
         Repackage and update the function code.
         """
 
+        if docker_image_uri:
+            self._check_docker_settings_conflicts()
+
         if not source_zip and not docker_image_uri:
             # Make sure we're in a venv.
             self.check_venv()
@@ -1142,7 +1168,7 @@ class ZappaCLI:
                         raise ClickException("Unable to upload handler to S3. Quitting.")
 
                     # Copy the project zip to the current project zip
-                    current_project_name = "{0!s}_{1!s}_current_project.tar.gz".format(self.api_stage, self.project_name)
+                    current_project_name = self._get_slim_handler_archive_name()
                     success = self.zappa.copy_on_s3(
                         src_file_name=self.zip_path,
                         dst_file_name=current_project_name,
@@ -1404,6 +1430,13 @@ class ZappaCLI:
         self.zappa.delete_lambda_function(self.lambda_name)
         if remove_logs:
             self.zappa.remove_lambda_function_logs(self.lambda_name)
+
+        # Remove the slim_handler project archive from S3 so a subsequent
+        # redeploy does not load stale code. See issue #1341.
+        if self.stage_config.get("slim_handler", False):
+            current_project_name = self._get_slim_handler_archive_name()
+            click.echo("Removing slim_handler project archive from S3: " + click.style(current_project_name, bold=True))
+            self.zappa.remove_from_s3(current_project_name, self.s3_bucket_name)
 
         # Delete auto-created EFS resources
         # Check if any EFS entries were auto-created (no Arn in original config)
@@ -3106,8 +3139,8 @@ class ZappaCLI:
 
         # If slim handler, path to project zip
         if self.stage_config.get("slim_handler", False):
-            settings_s += "ARCHIVE_PATH='s3://{0!s}/{1!s}_{2!s}_current_project.tar.gz'\n".format(
-                self.s3_bucket_name, self.api_stage, self.project_name
+            settings_s += "ARCHIVE_PATH='s3://{0!s}/{1!s}'\n".format(
+                self.s3_bucket_name, self._get_slim_handler_archive_name()
             )
 
             # since includes are for slim handler add the setting here by joining arbitrary list from zappa_settings file


### PR DESCRIPTION
Closes #1341.

## Summary

- Fail fast in `deploy`, `update`, and `save-python-settings-file` when a stage with `slim_handler` enabled is deployed via `--docker-image-uri`. That combination writes a stale `ARCHIVE_PATH` into `zappa_settings.py` and causes the container handler to overlay old code from S3 at cold start.
- `undeploy` now removes the `<stage>_<project>_current_project.tar.gz` archive from the configured S3 bucket when `slim_handler` was enabled, so a later redeploy cannot pull stale code.
- README: new "Settings that should NOT be used with Docker deployments" subsection calls out `slim_handler` and `runtime`.
- Extracted `_get_slim_handler_archive_name()` to DRY up the archive-name format string previously duplicated across `deploy`, `update`, `undeploy`, and `get_zappa_settings_string`.

## Test plan

- [x] `pipenv run pytest tests/test_core.py -k "slim_handler or docker or settings_py"` — 10 passed (6 new tests)
- [x] `pipenv run black --line-length 127 --check`
- [x] `pipenv run isort --check --profile=black`
- [x] `pipenv run mypy zappa`
- [ ] Manual: `zappa deploy -d <image>` against a stage with `slim_handler: true` shows the new error
- [ ] Manual: `zappa undeploy` on a slim_handler stage removes the project archive from S3