### PR TITLE
:memo: README: document two-statement resource policy for Function URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1170,6 +1170,15 @@ to change Zappa's behavior. Use these at your own risk!
         // NOTE: Function URLs do NOT include stage names in their paths. Unlike API Gateway v1/v2 which include
         // the stage name in the URL (e.g., /dev/mypath), Function URLs route directly to your app (e.g., /mypath).
         // This means SCRIPT_NAME will be empty for Function URL requests, and PATH_INFO will contain the full path.
+        //
+        // NOTE: When `function_url_enabled` is true with `authorizer: "NONE"`, Zappa attaches TWO
+        // resource-policy statements with `Principal: "*"`: `FunctionURLAllowPublicAccess` for
+        // `lambda:InvokeFunctionUrl` and `FunctionURLAllowPublicAccessInvoke` for `lambda:InvokeFunction`.
+        // Both are required for unsigned calls to succeed; the AWS docs example at
+        // https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html only shows the first statement,
+        // but in practice the URL returns 403 AccessDeniedException without the second (see #1393).
+        // If you are adding a Function URL manually (e.g. outside Zappa) and seeing 403s with NONE
+        // auth, this two-statement shape is the missing piece.
         "apigateway_version": "v1", // optional, API Gateway version to use. Can be "v1" or "v2". Default "v1".
         "architecture": "x86_64", // optional, Set Lambda Architecture, defaults to x86_64. For Graviton 2 use: arm64
         "async_source": "sns", // Source of async tasks. Defaults to "lambda"


### PR DESCRIPTION
## Description

Adds a NOTE block to the `function_url_enabled` section of the README explaining what resource policy statements Zappa attaches when `authorizer: "NONE"` is set.

PR #1393 (merged 2025-11-04) updated `zappa/core.py` to attach **two** resource-policy statements with `Principal: "*"`:

- `FunctionURLAllowPublicAccess` → `lambda:InvokeFunctionUrl` (with `FunctionUrlAuthType: NONE` condition)
- `FunctionURLAllowPublicAccessInvoke` → `lambda:InvokeFunction` (no condition)

That code change was correct — AWS now requires both for unsigned Function URL invocations. But the README's `function_url_enabled` section still doesn't mention it, and the [AWS docs example](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html) only shows the first statement. Users who try to follow AWS's example manually (e.g. `aws lambda create-function-url-config` + a single `aws lambda add-permission lambda:InvokeFunctionUrl`) hit 403 `AccessDeniedException` and assume the Lambda is misconfigured rather than the AWS docs being incomplete.

## Why this is helpful

This note captures what Zappa already does so:

- Users reverse-engineering Zappa's policy (to set up a Function URL manually, or to write their own deploy tooling on top of Zappa) don't have to discover the second statement empirically.
- The 403 → "two statements needed" leap is documented in the same place users will look first when their `function_url_enabled: true` deploy works but their manual Function URL attempts don't.

## Files changed

- `README.md` — 9-line NOTE block added after the existing stage-name NOTE in the `function_url_config` section. No behaviour change.

## GitHub Issues

References #1393 (which made the actual policy change). No new ticket — this is a docs-only follow-up to the merged change.