### PR TITLE
:sparkles: Default num_retained_versions to 5 to bound Lambda storage cost (#1453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* Change default of `num_retained_versions` from `null` (keep all) to `5` (#1453)
+  - Lambda code storage and SnapStart snapshot-cache cost now have a sane default upper bound.
+  - On the first `zappa update` after upgrade, published versions older than the newest 5 are deleted; versions referenced by an alias (e.g. ALB) and `$LATEST` are unaffected, but versions referenced by other aliases can still raise `ResourceConflictException` (see #960).
+  - To preserve previous behavior (keep all versions) set `"num_retained_versions": null` in `zappa_settings.json`.
+  - Pruned versions are now logged in the deploy output.
+  - `zappa init` / `zappa settings` now include `num_retained_versions` in generated `zappa_settings.json`.
 * Clarify Docker deployment handling for `slim_handler` (#1341)
   - `zappa deploy`, `zappa update`, and `zappa save-python-settings-file` now fail fast with a clear error when `--docker-image-uri` is used with a stage that sets `slim_handler` (this combination writes a stale `ARCHIVE_PATH` into `zappa_settings.py` and causes the container handler to load old code from S3).
   - `zappa undeploy` now removes the `<stage>_<project>_current_project.tar.gz` archive from the configured S3 bucket when `slim_handler` was enabled, so a later redeploy cannot load stale code.

--- a/README.md
+++ b/README.md
@@ -1270,7 +1270,7 @@ to change Zappa's behavior. Use these at your own risk!
         "memory_size": 512, // Lambda function memory in MB. Default 512.
         "ephemeral_storage": { "Size": 512 }, // Lambda function ephemeral_storage size in MB, Default 512, Max 10240
         "efs_config": [{ "Arn": "arn:aws:elasticfilesystem:...:access-point/fsap-...", "LocalMountPath": "/mnt/data" }], // Optional EFS configuration. See EFS section for details.
-        "num_retained_versions":null, // Indicates the number of old versions to retain for the lambda. If absent, keeps all the versions of the function.
+        "num_retained_versions":5, // Number of published Lambda versions to retain. Default 5. Older versions are deleted on `zappa update` to bound code-storage and (when SnapStart is enabled) snapshot-cache cost. Set to `null` to keep all versions.
         "payload_compression": true, // Whether or not to enable API gateway payload compression (default: true)
         "payload_minimum_compression_size": 0, // The threshold size (in bytes) below which payload compression will not be applied (default: 0)
         "prebuild_script": "your_module.your_function", // Function to execute before uploading code

--- a/test_settings.json
+++ b/test_settings.json
@@ -3,6 +3,7 @@
        "touch": false,
        "s3_bucket": "lmbda",
        "app_function": "tests.test_app.hello_world",
+       "num_retained_versions": null,
        "use_precompiled_packages": false,
        "callbacks": {
            "settings": "tests.test_app.callback",
@@ -235,5 +236,25 @@
             {"LocalMountPath": "/mnt/data"},
             {"LocalMountPath": "/mnt/data"}
         ]
+     },
+     "num_retained_versions_default": {
+        "s3_bucket": "lmbda",
+        "app_function": "tests.test_app.hello_world"
+     },
+     "num_retained_versions_null": {
+        "extends": "ttt888",
+        "num_retained_versions": null
+     },
+     "num_retained_versions_explicit": {
+        "extends": "ttt888",
+        "num_retained_versions": 10
+     },
+     "num_retained_versions_invalid_type": {
+        "extends": "ttt888",
+        "num_retained_versions": "not_an_int"
+     },
+     "num_retained_versions_invalid_value": {
+        "extends": "ttt888",
+        "num_retained_versions": 0
      }
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1820,6 +1820,8 @@ class TestZappa(unittest.TestCase):
             self.assertIn("dev", settings)
             self.assertEqual(settings["dev"]["app_function"], "app.app")
             self.assertEqual(settings["dev"]["aws_region"], "us-east-1")
+            # Generated settings should include num_retained_versions default
+            self.assertEqual(settings["dev"]["num_retained_versions"], 5)
 
             # Test settings command with custom stage (no ZAPPA_* env vars)
             with redirect_stdout(io.StringIO()) as f:
@@ -2295,6 +2297,43 @@ class TestZappa(unittest.TestCase):
         with self.assertRaises(ClickException) as context:
             zappa_cli.load_settings("test_settings.json")
         self.assertIn("not unique", str(context.exception))
+
+    def test_load_settings__num_retained_versions_default(self):
+        """Default num_retained_versions is 5 when not set in zappa_settings.json."""
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = "num_retained_versions_default"
+        zappa_cli.load_settings("test_settings.json")
+        self.assertEqual(5, zappa_cli.num_retained_versions)
+
+    def test_load_settings__num_retained_versions_null(self):
+        """num_retained_versions: null preserves the opt-out (keep all versions)."""
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = "num_retained_versions_null"
+        zappa_cli.load_settings("test_settings.json")
+        self.assertIsNone(zappa_cli.num_retained_versions)
+
+    def test_load_settings__num_retained_versions_explicit(self):
+        """An explicit integer value overrides the default."""
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = "num_retained_versions_explicit"
+        zappa_cli.load_settings("test_settings.json")
+        self.assertEqual(10, zappa_cli.num_retained_versions)
+
+    def test_load_settings__num_retained_versions_invalid_type(self):
+        """A non-int, non-null value raises ClickException."""
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = "num_retained_versions_invalid_type"
+        with self.assertRaises(ClickException) as context:
+            zappa_cli.load_settings("test_settings.json")
+        self.assertIn("num_retained_versions", str(context.exception))
+
+    def test_load_settings__num_retained_versions_invalid_value(self):
+        """A value less than 1 raises ClickException."""
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = "num_retained_versions_invalid_value"
+        with self.assertRaises(ClickException) as context:
+            zappa_cli.load_settings("test_settings.json")
+        self.assertIn("greater than 0", str(context.exception))
 
     def test_load_settings_yml(self):
         zappa_cli = ZappaCLI()

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -70,6 +70,7 @@ CUSTOM_SETTINGS = [
 BOTO3_CONFIG_DOCS_URL = "https://boto3.readthedocs.io/en/latest/guide/quickstart.html#configuration"
 DEFAULT_APP_FUNCTION = "app.app"
 DEFAULT_EXCLUDES = ["boto3", "dateutil", "botocore", "s3transfer", "concurrent"]
+DEFAULT_NUM_RETAINED_VERSIONS = 5
 
 
 ##
@@ -2322,6 +2323,7 @@ class ZappaCLI:
                 "runtime": get_venv_from_python_version(),
                 "project_name": self.get_project_name(),
                 "exclude": DEFAULT_EXCLUDES,
+                "num_retained_versions": DEFAULT_NUM_RETAINED_VERSIONS,
             }
         }
 
@@ -2704,13 +2706,13 @@ class ZappaCLI:
         dead_letter_arn = self.stage_config.get("dead_letter_arn", "")
         self.dead_letter_config = {"TargetArn": dead_letter_arn} if dead_letter_arn else {}
         self.cognito = self.stage_config.get("cognito", None)
-        self.num_retained_versions = self.stage_config.get("num_retained_versions", None)
+        # Default bounds Lambda code-storage and SnapStart snapshot-cache cost; null retains all versions.
+        self.num_retained_versions = self.stage_config.get("num_retained_versions", DEFAULT_NUM_RETAINED_VERSIONS)
         self.architecture = self.stage_config.get("architecture", "x86_64")
-        # Check for valid values of num_retained_versions
         if self.num_retained_versions is not None and type(self.num_retained_versions) is not int:
             raise ClickException(
-                "Please supply either an integer or null for num_retained_versions in the zappa_settings.json. Found %s"
-                % type(self.num_retained_versions)
+                "Please supply either an integer or null for num_retained_versions in the zappa_settings.json. "
+                "Use null to retain all published versions. Found %s" % type(self.num_retained_versions)
             )
         elif type(self.num_retained_versions) is int and self.num_retained_versions < 1:
             raise ClickException("The value for num_retained_versions in the zappa_settings.json should be greater than 0.")

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1370,8 +1370,16 @@ class Zappa:
                 for version in versions["Versions"]:
                     versions_in_lambda.append(version["Version"])
             versions_in_lambda.remove("$LATEST")
-            # Delete older revisions if their number exceeds the specified limit
-            for version in versions_in_lambda[::-1][num_revisions:]:
+            versions_to_delete = versions_in_lambda[::-1][num_revisions:]
+            if versions_to_delete:
+                logger.info(
+                    "Pruning %d Lambda function version(s) for %s (retaining latest %d): %s",
+                    len(versions_to_delete),
+                    function_name,
+                    num_revisions,
+                    ", ".join(versions_to_delete),
+                )
+            for version in versions_to_delete:
                 self.lambda_client.delete_function(FunctionName=function_name, Qualifier=version)
 
         self.wait_until_lambda_function_is_updated(function_name)


### PR DESCRIPTION
## Summary

Implements [#1453](https://github.com/zappa/Zappa/issues/1453) — change the default value of `num_retained_versions` from `null` (keep all) to `5`. Unbounded retention silently accrues storage cost, especially when SnapStart is enabled (a cached snapshot is stored per published version).

- `null` continues to mean "keep all" (explicit opt-out).
- Any positive integer continues to mean "keep the latest N".
- 5 is enough for practical rollback (`zappa rollback -n <num>` defaults to 1).

## Changes

- `zappa/cli.py`: New `DEFAULT_NUM_RETAINED_VERSIONS = 5` constant; applied at `load_settings()` and in `_generate_settings_dict()` so `zappa init` / `zappa settings` include the key.
- `zappa/core.py:update_lambda_function`: Log pruned versions (count + IDs) so the behavior change is visible in deploy output.
- `CHANGELOG.md`: Unreleased entry flagging the behavior change, the opt-out, and noting the related #960 alias-conflict concern.
- `README.md`: Settings comment updated with new default and cost rationale (code-storage + SnapStart snapshot-cache).
- `tests/test_core.py` + `test_settings.json`: 5 new tests covering default, null, explicit, invalid-type, invalid-value; existing `test_zappacli_settings` extended to assert generated default. `ttt888` pinned to `null` to preserve the recorded placebo flow in `test_cli_aws`.

## Backwards-Compatibility Note

This is a behavior change on upgrade: the next `zappa update` will prune versions older than the newest 5 for users who relied on the implicit "keep all" default. `$LATEST` and the ALB alias remain safe; versions referenced by other aliases can still raise `ResourceConflictException` ([#960](https://github.com/zappa/Zappa/issues/960)) — a pre-existing concern this change makes more likely to surface.

## Test plan

- [x] `make tests` → 261 passed
- [x] `make mypy`, `make black-check`, `make isort-check`, `make flake` → clean
- [x] Existing `test_cli_aws` placebo flow unaffected (ttt888 stage pinned to `null`)
- [x] 5 new unit tests for default, null, explicit, invalid-type, invalid-value
- [x] `test_zappacli_settings` asserts generated config includes `num_retained_versions: 5`