### PR TITLE
:bug: Fix v2 custom-domain double-stage redirect with path-segment-safe stage detection (#1409)

### DIFF
--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -689,3 +689,40 @@ class TestZappa(unittest.TestCase):
         self.assertIn("SCRIPT_NAME='/dev'", response["body"])
         self.assertIn("PATH_INFO='/debug/wsgi/environ'", response["body"])  # FIXED: stage stripped
         self.assertIn("/dev/debug/wsgi/environ", response["body"])  # Correct single prefix!
+
+    def test_wsgi_v2_custom_domain_no_double_stage(self):
+        """
+        Test that API Gateway v2 with a custom domain mapping doesn't double the
+        stage in URLs (#1409). When a custom domain maps to a stage, API Gateway
+        strips the stage from rawPath, so SCRIPT_NAME should be empty.
+        """
+        lh = LambdaHandler("tests.test_wsgi_script_name_settings")
+
+        event = {
+            "version": "2.0",
+            "routeKey": "$default",
+            "rawPath": "/return/request/url",  # Custom domain: stage already stripped
+            "rawQueryString": "",
+            "headers": {
+                "host": "api.example.com",
+            },
+            "requestContext": {
+                "http": {
+                    "method": "GET",
+                    "path": "/return/request/url",
+                },
+                "stage": "dev",  # Stage is still present in requestContext
+                "domainName": "api.example.com",
+            },
+            "isBase64Encoded": False,
+            "body": "",
+        }
+        response = lh.handler(event, None)
+
+        self.assertEqual(response["statusCode"], 200)
+        # With custom domain, stage is NOT in rawPath, so SCRIPT_NAME should be empty
+        # and the URL should NOT contain /dev prefix
+        self.assertEqual(
+            response["body"],
+            "https://api.example.com/return/request/url",
+        )

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -726,3 +726,40 @@ class TestZappa(unittest.TestCase):
             response["body"],
             "https://api.example.com/return/request/url",
         )
+
+    def test_wsgi_v2_custom_domain_route_sharing_stage_prefix(self):
+        """
+        Test that a custom-domain route whose top path segment merely shares a
+        leading substring with the stage name (stage "dev" + path "/devices/...")
+        is not mistaken for direct API Gateway access (#1409). The stage must be
+        matched on a path-segment boundary, not a bare string prefix.
+        """
+        lh = LambdaHandler("tests.test_wsgi_script_name_settings")
+
+        event = {
+            "version": "2.0",
+            "routeKey": "$default",
+            "rawPath": "/devices/list",  # Custom domain: stage stripped; starts with "/dev"
+            "rawQueryString": "",
+            "headers": {
+                "host": "api.example.com",
+            },
+            "requestContext": {
+                "http": {
+                    "method": "GET",
+                    "path": "/devices/list",
+                },
+                "stage": "dev",
+                "domainName": "api.example.com",
+            },
+            "isBase64Encoded": False,
+            "body": "",
+        }
+        response = lh.handler(event, None)
+
+        self.assertEqual(response["statusCode"], 200)
+        # The "/dev" stage must NOT be stripped from "/devices/list".
+        self.assertEqual(
+            response["body"],
+            "https://api.example.com/devices/list",
+        )

--- a/tests/test_wsgi_script_name_app.py
+++ b/tests/test_wsgi_script_name_app.py
@@ -8,6 +8,11 @@ def return_request_url():
     return request.url
 
 
+@app.route("/devices/list", methods=["GET"])  # Top segment shares the "dev" stage string prefix
+def devices_list():
+    return request.url
+
+
 @app.route("/debug/wsgi/environ", methods=["GET"])  # Route without stage prefix (Flask sees clean path)
 def debug_wsgi_environ():
     """Debug endpoint to inspect WSGI environ values"""

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -711,13 +711,16 @@ class LambdaHandler:
                 stage = request_context.get("stage")
 
                 # For API Gateway v2, the stage is included in rawPath and we need to
-                # set script_name so it can be stripped from PATH_INFO
-                # For Function URLs (no stage), leave script_name empty
-                if stage:
-                    # API Gateway v2 with named stage - rawPath includes the stage
+                # set script_name so it can be stripped from PATH_INFO.
+                # When using a custom domain with API mapping, API Gateway already
+                # strips the stage from rawPath, so we detect this and skip setting
+                # script_name to avoid double-stage redirects (#1409).
+                raw_path = event.get("rawPath", "")
+                if stage and raw_path.startswith(f"/{stage}"):
+                    # Direct API Gateway v2 access - rawPath includes the stage
                     script_name = f"/{stage}"
                 else:
-                    # Function URL - no stage
+                    # Function URL or custom domain (stage already stripped)
                     script_name = ""
 
                 # ASGI path

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -715,8 +715,13 @@ class LambdaHandler:
                 # When using a custom domain with API mapping, API Gateway already
                 # strips the stage from rawPath, so we detect this and skip setting
                 # script_name to avoid double-stage redirects (#1409).
+                # Match the stage on a path-segment boundary, not a bare string prefix,
+                # so a custom-domain route that merely shares a leading substring with
+                # the stage name (e.g. stage "prod" + path "/products") is not mistaken
+                # for direct access.
                 raw_path = event.get("rawPath", "")
-                if stage and raw_path.startswith(f"/{stage}"):
+                stage_prefix = f"/{stage}"
+                if stage and (raw_path == stage_prefix or raw_path.startswith(f"{stage_prefix}/")):
                     # Direct API Gateway v2 access - rawPath includes the stage
                     script_name = f"/{stage}"
                 else:


### PR DESCRIPTION
## Summary

Supersedes #1440 — keeps that fix for the API Gateway v2 + custom-domain double-stage redirect (#1409) and hardens the stage detection.

#1440 decides whether `rawPath` carries the stage with `raw_path.startswith(f"/{stage}")`. That is an unanchored string prefix: a custom-domain route whose top path segment merely shares a leading substring with the stage name is misclassified as direct API Gateway access, the stage gets stripped from `PATH_INFO`, and the double-stage redirect returns.

- Stage `prod`, custom domain, request `/products/123` → `"/products/123".startswith("/prod")` is `True` → `SCRIPT_NAME="/prod"` → `PATH_INFO` stripped to `ucts/123` (404) and `/prod` re-added to generated URLs.
- Same class of break for stage `dev` + `/development`, stage `api` + `/apidocs`, stage `v1` + `/v1xyz`.

## Fix

Match the stage on a **path-segment boundary** — exact match or a `"/{stage}/"` prefix — instead of a bare string prefix:

```python
if stage and (raw_path == stage_prefix or raw_path.startswith(f"{stage_prefix}/")):
    script_name = f"/{stage}"
else:
    script_name = ""
```

Direct API Gateway access (`/dev`, `/dev/foo`), Function URLs (`$default`), and custom-domain access (stage stripped) all behave correctly.

## Test plan

- [x] Added `test_wsgi_v2_custom_domain_route_sharing_stage_prefix` — custom-domain event with `rawPath=/devices/list` (shares the `/dev` prefix) must return `https://api.example.com/devices/list` without stripping. Fails on the old prefix check (`GET ices/list … 404`), passes with the fix.
- [x] Retains #1440's `test_wsgi_v2_custom_domain_no_double_stage`.
- [x] All 26 `tests/test_handler.py` tests pass; `black`, `isort`, `flake8` clean.

Fixes #1409
