### PR TITLE
Support multiple functions per AWS event, merge SNS filter policies

### DIFF
--- a/test_settings.py
+++ b/test_settings.py
@@ -16,11 +16,11 @@ REMOTE_ENV = "s3://lmbda/test_env.json"
 #
 
 AWS_EVENT_MAPPING = {
-    "arn:aws:s3:1": "test_settings.aws_s3_event",
-    "arn:aws:sns:1": "test_settings.aws_sns_event",
-    "arn:aws:dynamodb:1": "test_settings.aws_dynamodb_event",
-    "arn:aws:kinesis:1": "test_settings.aws_kinesis_event",
-    "arn:aws:sqs:1": "test_settings.aws_sqs_event",
+    "arn:aws:s3:1": ["test_settings.aws_s3_event"],
+    "arn:aws:sns:1": ["test_settings.aws_sns_event"],
+    "arn:aws:dynamodb:1": ["test_settings.aws_dynamodb_event"],
+    "arn:aws:kinesis:1": ["test_settings.aws_kinesis_event"],
+    "arn:aws:sqs:1": ["test_settings.aws_sqs_event"],
 }
 
 ENVIRONMENT_VARIABLES = {"testenv": "envtest"}

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -763,3 +763,58 @@ class TestZappa(unittest.TestCase):
             response["body"],
             "https://api.example.com/devices/list",
         )
+
+    def test_handler_calls_multiple_functions_for_same_arn(self):
+        """Multiple handlers registered for the same SNS ARN should all be invoked."""
+        LambdaHandler._LambdaHandler__instance = None
+        LambdaHandler.settings = None
+        LambdaHandler.settings_name = None
+
+        lh = LambdaHandler("test_settings")
+
+        # Override AWS_EVENT_MAPPING with two handlers for the same ARN
+        lh.settings.AWS_EVENT_MAPPING = {
+            "arn:aws:sns:1": ["test_settings.aws_sns_event", "test_settings.aws_s3_event"],
+        }
+
+        event = {
+            "Records": [
+                {
+                    "Sns": {
+                        "Message": "Hello from SNS!",
+                        "TopicArn": "arn:aws:sns:1",
+                    },
+                }
+            ],
+        }
+
+        result = lh.handler(event, None)
+        # The last handler's result is returned
+        self.assertIsNotNone(result)
+
+    def test_handler_backward_compat_string_event_mapping(self):
+        """Old-format string values in AWS_EVENT_MAPPING should still work."""
+        LambdaHandler._LambdaHandler__instance = None
+        LambdaHandler.settings = None
+        LambdaHandler.settings_name = None
+
+        lh = LambdaHandler("test_settings")
+
+        # Override with old string format
+        lh.settings.AWS_EVENT_MAPPING = {
+            "arn:aws:sns:1": "test_settings.aws_sns_event",
+        }
+
+        event = {
+            "Records": [
+                {
+                    "Sns": {
+                        "Message": "Hello from SNS!",
+                        "TopicArn": "arn:aws:sns:1",
+                    },
+                }
+            ],
+        }
+
+        result = lh.handler(event, None)
+        self.assertEqual(result, "AWS SNS EVENT")

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -23,6 +23,7 @@ from zappa.utilities import (
     get_venv_from_python_version,
     human_size,
     is_valid_bucket_name,
+    merge_sns_filter_policies,
     parse_s3_url,
     string_to_timestamp,
     titlecase_keys,
@@ -496,4 +497,43 @@ class EventSourceMappingStatusTestCase(unittest.TestCase):
         )
         mixin = self._make_mixin(mock_client)
         result = mixin.status("arn:aws:lambda:us-east-1:123456789:function:my-func")
+        self.assertIsNone(result)
+
+
+class TestMergeSnsFilterPolicies(unittest.TestCase):
+    def test_both_none(self):
+        self.assertIsNone(merge_sns_filter_policies(None, None))
+
+    def test_existing_none(self):
+        self.assertIsNone(merge_sns_filter_policies(None, {"store": ["A"]}))
+
+    def test_new_none(self):
+        self.assertIsNone(merge_sns_filter_policies({"store": ["A"]}, None))
+
+    def test_same_keys_union_values(self):
+        existing = {"store": ["A", "B"]}
+        new = {"store": ["B", "C"]}
+        result = merge_sns_filter_policies(existing, new)
+        self.assertIsNotNone(result)
+        self.assertEqual(sorted(result["store"]), ["A", "B", "C"])
+
+    def test_disjoint_keys_omitted(self):
+        existing = {"store": ["A"]}
+        new = {"region": ["us-east-1"]}
+        result = merge_sns_filter_policies(existing, new)
+        # Both keys only in one filter → both omitted → empty → None
+        self.assertIsNone(result)
+
+    def test_partial_overlap(self):
+        existing = {"store": ["A"], "type": ["order"]}
+        new = {"store": ["B"], "priority": ["high"]}
+        result = merge_sns_filter_policies(existing, new)
+        # "type" and "priority" only in one → omitted; "store" in both → union
+        self.assertIsNotNone(result)
+        self.assertEqual(sorted(result["store"]), ["A", "B"])
+        self.assertNotIn("type", result)
+        self.assertNotIn("priority", result)
+
+    def test_both_empty(self):
+        result = merge_sns_filter_policies({}, {})
         self.assertIsNone(result)

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -3161,7 +3161,7 @@ class ZappaCLI:
             arn = event.get("event_source", {}).get("arn")
             function = event.get("function")
             if arn and function:
-                event_mapping[arn] = function
+                event_mapping.setdefault(arn, []).append(function)
         settings_s = settings_s + "AWS_EVENT_MAPPING={0!s}\n".format(event_mapping)
 
         # Map Lext bot events

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -3468,6 +3468,8 @@ class Zappa:
                     logger.info(f"Created {svc} event schedule for {function}!")
                 elif rule_response == "failed":
                     logger.error(f"Problem creating {svc} event schedule for {function}!")
+                elif rule_response == "updated":
+                    logger.info(f"Updated {svc} event schedule for {function}.")
                 elif rule_response == "exists":
                     logger.warning(f"{svc} event schedule for {function} already exists - Nothing to do here.")
                 elif rule_response == "dryrun":

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -639,14 +639,14 @@ class LambdaHandler:
         """
         if "s3" in record:
             if ":" in record["s3"]["configurationId"]:
-                return record["s3"]["configurationId"].split(":")[-1]
+                return [record["s3"]["configurationId"].split(":")[-1]]
 
         arn = None
         if "Sns" in record:
             try:
                 message = json.loads(record["Sns"]["Message"])
                 if message.get("command"):
-                    return message["command"]
+                    return [message["command"]]
             except ValueError:
                 pass
             arn = record["Sns"].get("TopicArn")
@@ -658,9 +658,15 @@ class LambdaHandler:
             arn = record["s3"]["bucket"]["arn"]
 
         if arn:
-            return self.settings.AWS_EVENT_MAPPING.get(arn)
+            value = self.settings.AWS_EVENT_MAPPING.get(arn)
+            if value is None:
+                return []
+            # Backward compat: old format stores a single string
+            if isinstance(value, str):
+                return [value]
+            return value
 
-        return None
+        return []
 
     def get_function_from_bot_intent_trigger(self, event):
         """
@@ -936,11 +942,12 @@ class LambdaHandler:
         elif event.get("Records", None):
             records = event.get("Records")
             result = None
-            whole_function = self.get_function_for_aws_event(records[0])
-            if whole_function:
-                app_function = self.import_module_and_get_function(whole_function)
-                result = self.run_function(app_function, event, context)
-                logger.debug(result)
+            functions = self.get_function_for_aws_event(records[0])
+            if functions:
+                for whole_function in functions:
+                    app_function = self.import_module_and_get_function(whole_function)
+                    result = self.run_function(app_function, event, context)
+                    logger.debug(result)
             else:
                 logger.error("Cannot find a function to process the triggered event.")
             return result

--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -542,9 +542,7 @@ class S3EventSource(BaseEventSource):
         self.add(function_arn)
 
 
-def merge_sns_filter_policies(
-    existing: Optional[Dict[str, Any]], new: Optional[Dict[str, Any]]
-) -> Optional[Dict[str, Any]]:
+def merge_sns_filter_policies(existing: Optional[Dict[str, Any]], new: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """Merge two SNS filter policies into one broader policy.
 
     Rules:

--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -542,6 +542,28 @@ class S3EventSource(BaseEventSource):
         self.add(function_arn)
 
 
+def merge_sns_filter_policies(
+    existing: Optional[Dict[str, Any]], new: Optional[Dict[str, Any]]
+) -> Optional[Dict[str, Any]]:
+    """Merge two SNS filter policies into one broader policy.
+
+    Rules:
+    - Either is None → result is None (match all)
+    - Key in only one filter → omit from merged (omission = match all for that attribute)
+    - Key in both → union the value lists
+    """
+    if existing is None or new is None:
+        return None
+
+    all_keys = set(existing) | set(new)
+    merged = {}
+    for key in all_keys:
+        if key in existing and key in new:
+            merged[key] = list(set(existing[key]) | set(new[key]))
+        # Key in only one → omit (match all for that attribute)
+    return merged if merged else None
+
+
 class SNSEventSource(BaseEventSource):
     """SNS event source implementation"""
 
@@ -616,18 +638,35 @@ class SNSEventSource(BaseEventSource):
             return None
 
     def update(self, function_arn: str) -> None:
-        # For SNS, update means updating filters if they exist
-        if self.filters:
-            subscription = self.status(function_arn)
-            if subscription:
-                try:
-                    self._sns.set_subscription_attributes(
-                        SubscriptionArn=subscription["SubscriptionArn"],
-                        AttributeName="FilterPolicy",
-                        AttributeValue=json.dumps(self.filters),
-                    )
-                except Exception:
-                    LOG.exception("Unable to update SNS filters")
+        # Merge new filters with existing filters on the subscription
+        subscription = self.status(function_arn)
+        if not subscription:
+            return
+
+        try:
+            attrs = self._sns.get_subscription_attributes(SubscriptionArn=subscription["SubscriptionArn"])
+            existing_policy_str = attrs.get("Attributes", {}).get("FilterPolicy")
+            existing_policy = json.loads(existing_policy_str) if existing_policy_str else None
+        except Exception:
+            LOG.exception("Unable to get existing SNS filter policy")
+            existing_policy = None
+
+        merged = merge_sns_filter_policies(existing_policy, self.filters)
+        try:
+            if merged is None:
+                self._sns.set_subscription_attributes(
+                    SubscriptionArn=subscription["SubscriptionArn"],
+                    AttributeName="FilterPolicy",
+                    AttributeValue="",
+                )
+            else:
+                self._sns.set_subscription_attributes(
+                    SubscriptionArn=subscription["SubscriptionArn"],
+                    AttributeName="FilterPolicy",
+                    AttributeValue=json.dumps(merged),
+                )
+        except Exception:
+            LOG.exception("Unable to update SNS filters")
 
 
 class CloudWatchEventSource(BaseEventSource):
@@ -760,13 +799,13 @@ def add_event_source(
     Given an event_source dictionary, create the object and add the event source.
     """
     event_source_obj, function_arn = get_event_source(event_source, lambda_arn, target_function, boto_session, dry=False)
-    # TODO: Detect changes in config and refine exists algorithm
     if not dry:
         if not event_source_obj.status(function_arn):
             event_source_obj.add(function_arn)
             return "successful" if event_source_obj.status(function_arn) else "failed"
         else:
-            return "exists"
+            event_source_obj.update(function_arn)
+            return "updated"
 
     return "dryrun"
 


### PR DESCRIPTION
## Summary
- `AWS_EVENT_MAPPING` now maps an ARN to a list of functions instead of a single function (with backward-compat handling for the old single-string format), so multiple Lambda functions can respond to the same triggering event/ARN.
- `SNSEventSource.update()` now merges a new filter policy with the subscription's existing filter policy instead of overwriting it.

## Test plan
- [ ] `pytest tests/test_handler.py tests/test_utilities.py"