### PR TITLE
Fix merge_headers() joining multiple Cookie headers with ", "

### DIFF
--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -312,12 +312,16 @@ USE_TZ = True
     def test_merge_headers_joins_cookie_with_semicolon(self):
         # HTTP/2 clients may send the cookie header as multiple field lines;
         # they must be re-joined with "; ", not ", ", for WSGI frameworks to parse them.
-        event = {
-            "headers": {"Cookie": "csrftoken=AAAA"},
-            "multiValueHeaders": {"Cookie": ["csrftoken=AAAA", "sessionid=BBBB"]},
-        }
-        merged = merge_headers(event)
-        self.assertEqual(merged["Cookie"], "csrftoken=AAAA; sessionid=BBBB")
+        for header_name in ("Cookie", "cookie"):
+            with self.subTest(header_name=header_name):
+                event = {
+                    "headers": {header_name: "csrftoken=AAAA"},
+                    "multiValueHeaders": {
+                        header_name: ["csrftoken=AAAA", "sessionid=BBBB"]
+                    },
+                }
+                merged = merge_headers(event)
+                self.assertEqual(merged[header_name], "csrftoken=AAAA; sessionid=BBBB")
 
     def test_merge_headers_joins_other_headers_with_comma(self):
         event = {

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -23,6 +23,7 @@ from zappa.utilities import (
     get_venv_from_python_version,
     human_size,
     is_valid_bucket_name,
+    merge_headers,
     parse_s3_url,
     string_to_timestamp,
     titlecase_keys,
@@ -307,6 +308,24 @@ USE_TZ = True
 
         self.assertTrue(is_valid_bucket_name("valid-formed-s3-bucket-name"))
         self.assertTrue(is_valid_bucket_name("worst.bucket.ever"))
+
+    def test_merge_headers_joins_cookie_with_semicolon(self):
+        # HTTP/2 clients may send the cookie header as multiple field lines;
+        # they must be re-joined with "; ", not ", ", for WSGI frameworks to parse them.
+        event = {
+            "headers": {"Cookie": "csrftoken=AAAA"},
+            "multiValueHeaders": {"Cookie": ["csrftoken=AAAA", "sessionid=BBBB"]},
+        }
+        merged = merge_headers(event)
+        self.assertEqual(merged["Cookie"], "csrftoken=AAAA; sessionid=BBBB")
+
+    def test_merge_headers_joins_other_headers_with_comma(self):
+        event = {
+            "headers": {},
+            "multiValueHeaders": {"Accept": ["text/html", "application/json"]},
+        }
+        merged = merge_headers(event)
+        self.assertEqual(merged["Accept"], "text/html, application/json")
 
 
 class ApacheNCSAFormatterTestCase(unittest.TestCase):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -316,9 +316,7 @@ USE_TZ = True
             with self.subTest(header_name=header_name):
                 event = {
                     "headers": {header_name: "csrftoken=AAAA"},
-                    "multiValueHeaders": {
-                        header_name: ["csrftoken=AAAA", "sessionid=BBBB"]
-                    },
+                    "multiValueHeaders": {header_name: ["csrftoken=AAAA", "sessionid=BBBB"]},
                 }
                 merged = merge_headers(event)
                 self.assertEqual(merged[header_name], "csrftoken=AAAA; sessionid=BBBB")

--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -963,7 +963,10 @@ def merge_headers(event: Dict[str, Any]) -> Dict[str, str]:
         if h not in multi_headers:
             multi_headers[h] = [headers[h]]
     for h in multi_headers.keys():
-        multi_headers[h] = ", ".join(multi_headers[h])
+        # Cookies are joined with "; ", not ", " (RFC 6265).
+        # HTTP/2 clients may send the cookie header as multiple field lines.
+        separator = "; " if h.lower() == "cookie" else ", "
+        multi_headers[h] = separator.join(multi_headers[h])
     return multi_headers
 
 


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/zappa/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of: **Python 3.9**, **Python 3.10**, **Python 3.11**, **Python 3.12**, **Python 3.13**, and **Python 3.14**?

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description

<!-- Please describe the changes included in this PR -->

Fixes #1466

`merge_headers()` joins all multi-value headers with `", "`, 
including `Cookie` — but cookies are separated by `"; "`, not commas.
HTTP/2 clients such as Chrome may split the cookie header into multiple field lines, 
which API Gateway payload v1 delivers via `multiValueHeaders`.
Zappa then reassembles them as `csrftoken=A, sessionid=B`, 
which WSGI frameworks cannot parse — `sessionid` is silently dropped and session auth breaks (e.g. Django login loops).

The payload v2 path already joins `event["cookies"]` with `"; "`
(`zappa/wsgi.py`), so this change brings v1 in line with v2.

## GitHub Issues

<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

#1466