### PR TITLE
:bug: Skip keep-warm import of handler.keep_warm_callback (#1469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fix keep-warm `ModuleNotFoundError: No module named 'handler'` when there is no zip-root `handler.py` (#1469)
+  - Scheduled keep-warm events no longer import `handler.keep_warm_callback`.
+  - That import only works for classic zip deploys that copy `handler.py` to the archive root; custom `lambda_handler` / container images do not have that module.
+  - `LambdaHandler` construction already loads the app, so the extra import is unnecessary.
 * Change default of `num_retained_versions` from `null` (keep all) to `5` (#1453)
   - Lambda code storage and SnapStart snapshot-cache cost now have a sane default upper bound.
   - On the first `zappa update` after upgrade, published versions older than the newest 5 are deleted; versions referenced by an alias (e.g. ALB) and `$LATEST` are unaffected, but versions referenced by other aliases can still raise `ResourceConflictException` (see #960).

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -763,3 +763,39 @@ class TestZappa(unittest.TestCase):
             response["body"],
             "https://api.example.com/devices/list",
         )
+
+    def test_keep_warm_scheduled_event_without_handler_module(self):
+        """
+        Keep-warm EventBridge rules encode handler.keep_warm_callback.
+        LambdaHandler construction already loaded the app, so this must
+        not import a top-level handler module (#1469).
+        """
+        lh = LambdaHandler("tests.test_wsgi_script_name_settings")
+        event = {
+            "account": "123456789012",
+            "region": "us-east-1",
+            "detail": {},
+            "detail-type": "Scheduled Event",
+            "source": "aws.events",
+            "version": "0",
+            "time": "2026-08-18T18:04:39Z",
+            "id": "c6c1bea9-5846-4008-9947-57c1c5fb03d5",
+            "resources": ["arn:aws:events:us-east-1:123456789012:rule/myapp-prod-zappa-keep-warm-handler.keep_warm_callback"],
+        }
+
+        response = lh.handler(event, None)
+
+        self.assertIsNone(response)
+
+    def test_scheduled_event_invokes_target_function(self):
+        """User-configured scheduled events still import and run the target."""
+        lh = LambdaHandler("tests.test_wsgi_script_name_settings")
+        event = {
+            "detail-type": "Scheduled Event",
+            "source": "aws.events",
+            "resources": ["arn:aws:events:us-east-1:123456789012:rule/myapp-prod-tests.test_app.schedule_me"],
+        }
+
+        response = lh.handler(event, None)
+
+        self.assertEqual(response, "Hello!")

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -887,6 +887,12 @@ class LambdaHandler:
         elif event.get("detail-type") == "Scheduled Event":
             whole_function = event["resources"][0].split("/")[-1].split("-")[-1]
 
+            # Keep-warm is scheduled as handler.keep_warm_callback, but that
+            # module only exists when the zip-root handler.py copy is packaged.
+            # LambdaHandler construction already loaded the app. See #1469.
+            if whole_function.rsplit(".", 1)[-1] == "keep_warm_callback":
+                return
+
             # This is a scheduled function.
             if "." in whole_function:
                 app_function = self.import_module_and_get_function(whole_function)
@@ -894,7 +900,7 @@ class LambdaHandler:
                 # Execute the function!
                 return self.run_function(app_function, event, context)
 
-            # Keep-warm / recertify: initialization already done by singleton
+            # Recertify: initialization already done by singleton
 
         # This is a direct command invocation.
         elif event.get("command", None):


### PR DESCRIPTION
## Summary

Fixes #1469.

When `keep_warm` is on (the default), Zappa schedules an EventBridge rule whose target is hardcoded as `handler.keep_warm_callback`. On invoke, `LambdaHandler` treats that string as an import path. That works for a classic zip (the package copies `zappa/handler.py` to the archive root as `handler.py`). It fails for a custom `lambda_handler` / container image that has no top-level `handler` module:

```
ModuleNotFoundError: No module named 'handler'
```

HTTP can still succeed. The keep-warm ping fails every few minutes.

## Fix

In the Scheduled Event branch, if the extracted function name ends in `keep_warm_callback`, return after `LambdaHandler` construction. Do **not** import `handler.keep_warm_callback`.

- Existing EventBridge rules keep their current name, so this fixes production on the next code deploy.
- Classic zip deploys are unchanged.
- User-configured scheduled functions still import and run (`function` cannot contain hyphens, so `split("-")[-1]` is the full dotted path).
- The extra `keep_warm_callback` re-entry (`lambda_handler(event={})`) was not load-bearing: `__init__` already loads the app.

The CLI still schedules `handler.keep_warm_callback`. Changing that string would rename the rule and would not fix existing rules.

## Test plan

- [x] `test_keep_warm_scheduled_event_without_handler_module` — Scheduled Event whose rule ARN ends in `zappa-keep-warm-handler.keep_warm_callback`, with no top-level `handler` module, must not raise `ModuleNotFoundError`. Fails without the special-case, passes with it.
- [x] `test_scheduled_event_invokes_target_function` — a real scheduled target (`tests.test_app.schedule_me`) still imports and runs.
- [x] All 28 `tests/test_handler.py` tests pass; `black`, `isort`, `flake8` clean on touched Python.

Fixes #1469
